### PR TITLE
[BREAKING CHANGE] fix: make db and redis dependencies soft/opt-out

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -69,7 +69,7 @@ ADMIN_DOMAIN="${APP_DOMAIN}"
 # @default true
 # @see https://docs.pixelfed.org/technical-documentation/config/#config_cache
 # @dottie/validate boolean
-ENABLE_CONFIG_CACHE="true"
+ENABLE_CONFIG_CACHE="false"
 
 # Enable/disable new local account registrations.
 #

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -292,10 +292,34 @@ jobs:
         run: docker compose config
 
       - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
-        name: Show docker compose logs
+        name: Show docker compose logs (web)
+        run: |
+          docker compose logs web
+
+      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
+        name: Show docker compose logs (worker)
+        run: |
+          docker compose logs worker
+
+      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
+        name: Show docker compose logs (cron)
+        run: |
+          docker compose logs web
+
+      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
+        name: Show docker compose logs (db)
+        run: |
+          docker compose logs db
+
+      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
+        name: Show docker compose logs (redis)
+        run: |
+          docker compose logs redis
+
+      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
+        name: Show docker compose logs (ALL)
         run: |
           docker compose logs
-          docker compose down -v
 
       - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -292,6 +292,10 @@ jobs:
         run: docker compose config
 
       - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
+        name: Show .env file
+        run: cat .env
+
+      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
         name: Show docker compose logs (web)
         run: |
           docker compose logs web --no-log-prefix --timestamps

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -294,32 +294,32 @@ jobs:
       - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
         name: Show docker compose logs (web)
         run: |
-          docker compose logs web
+          docker compose logs web --no-log-prefix --timestamps
 
       - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
         name: Show docker compose logs (worker)
         run: |
-          docker compose logs worker
+          docker compose logs worker --no-log-prefix --timestamps
 
       - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
         name: Show docker compose logs (cron)
         run: |
-          docker compose logs web
+          docker compose logs web --no-log-prefix --timestamps
 
       - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
         name: Show docker compose logs (db)
         run: |
-          docker compose logs db
+          docker compose logs db --no-log-prefix --timestamps
 
       - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
         name: Show docker compose logs (redis)
         run: |
-          docker compose logs redis
+          docker compose logs redis --no-log-prefix --timestamps
 
       - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
         name: Show docker compose logs (ALL)
         run: |
-          docker compose logs
+          docker compose logs --timestamps
 
       - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
         uses: actions/upload-artifact@v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,9 +107,14 @@ services:
       com.github.nginx-proxy.nginx-proxy.http3.enable: true
     ports:
       - "${DOCKER_WEB_PORT_EXTERNAL_HTTP}:80"
+    # https://docs.docker.com/compose/compose-file/05-services/#depends_on
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+        required: false
+      redis:
+        condition: service_healthy
+        required: false
     healthcheck:
       test: 'curl --header "Host: ${APP_DOMAIN}" --fail http://localhost/api/service/health-check'
       interval: "${DOCKER_WEB_HEALTHCHECK_INTERVAL}"
@@ -148,9 +153,14 @@ services:
       - "${DOCKER_APP_HOST_CACHE_PATH}:/var/www/bootstrap/cache"
       - "${DOCKER_APP_HOST_OVERRIDES_PATH}:/docker/overrides:ro"
       - "${DOCKER_APP_HOST_STORAGE_PATH}:/var/www/storage"
+    # https://docs.docker.com/compose/compose-file/05-services/#depends_on
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+        required: false
+      redis:
+        condition: service_healthy
+        required: false
     healthcheck:
       test: gosu www-data php artisan horizon:status | grep running
       interval: "${DOCKER_WORKER_HEALTHCHECK_INTERVAL:?error}"
@@ -188,9 +198,14 @@ services:
       - "${DOCKER_ALL_HOST_CONFIG_ROOT_PATH}/proxy/conf.d:/shared/proxy/conf.d"
       - "${DOCKER_APP_HOST_CACHE_PATH}:/var/www/bootstrap/cache"
       - "${DOCKER_APP_HOST_OVERRIDES_PATH}:/docker/overrides:ro"
+    # https://docs.docker.com/compose/compose-file/05-services/#depends_on
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+        required: false
+      redis:
+        condition: service_healthy
+        required: false
 
   db:
     image: ${DOCKER_DB_IMAGE:?error}

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.sh
@@ -28,7 +28,7 @@ entrypoint-set-script-name "entrypoint.sh"
 # Convert ENTRYPOINT_SKIP_SCRIPTS into a native bash array for easier lookup
 declare -a skip_scripts
 # shellcheck disable=SC2034
-IFS=' ' read -r -a skip_scripts <<< "$ENTRYPOINT_SKIP_SCRIPTS"
+IFS=' ' read -r -a skip_scripts <<<"$ENTRYPOINT_SKIP_SCRIPTS"
 
 # Ensure the entrypoint root folder exists
 mkdir -p "${ENTRYPOINT_D_ROOT}"
@@ -101,5 +101,8 @@ done
 release-lock "entrypoint.sh"
 
 log-info "Configuration complete; ready for start up"
+
+# Reload config files before running the process (in case of the files being changed during startup)
+load-config-files
 
 exec "$@"

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.sh
@@ -102,7 +102,4 @@ release-lock "entrypoint.sh"
 
 log-info "Configuration complete; ready for start up"
 
-# Reload config files before running the process (in case of the files being changed during startup)
-load-config-files
-
 exec "$@"

--- a/images/pixelfed/tests/e2e.sh
+++ b/images/pixelfed/tests/e2e.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset -o pipefail
 
-echo "==> Checking environment requirements"
+echo "==> Checking system requirements"
 scripts/check-requirements
 
 echo "==> Copying .env file"

--- a/images/pixelfed/tests/e2e.sh
+++ b/images/pixelfed/tests/e2e.sh
@@ -17,13 +17,14 @@ docker run --quiet --detach --name ngrok --env NGROK_AUTHTOKEN --net=host ngrok/
 echo "==> Following ngrok logs"
 docker logs ngrok -f &
 
-while true; do
+for _ in {1..10}; do
     echo "==> Finding ngrok tunnel public URL"
     domain="$(curl --retry-all-errors --fail --retry 60 --retry-max-time 60 http://127.0.0.1:4040/api/tunnels | jq -r ".tunnels[0].public_url")"
 
     case $domain in
         "" | "null")
             echo "===> got empty value, sleeping and retrying again"
+
             sleep 1
             ;;
 

--- a/images/pixelfed/tests/e2e.sh
+++ b/images/pixelfed/tests/e2e.sh
@@ -17,9 +17,22 @@ docker run --quiet --detach --name ngrok --env NGROK_AUTHTOKEN --net=host ngrok/
 echo "==> Following ngrok logs"
 docker logs ngrok -f &
 
-echo "==> Finding ngrok tunnel public URL"
-domain="$(curl --retry-all-errors --fail --retry 60 --retry-max-time 60 http://127.0.0.1:4040/api/tunnels | jq -r ".tunnels[0].public_url")"
-echo "OK: ${domain}"
+while true; do
+    echo "==> Finding ngrok tunnel public URL"
+    domain="$(curl --retry-all-errors --fail --retry 60 --retry-max-time 60 http://127.0.0.1:4040/api/tunnels | jq -r ".tunnels[0].public_url")"
+
+    case $domain in
+        "" | "null")
+            echo "===> got empty value, sleeping and retrying again"
+            sleep 1
+            ;;
+
+        *)
+            echo "OK: ${domain}"
+            break
+            ;;
+    esac
+done
 
 echo "==> Finding ngrok tunnel public host (domain without https://)"
 app_domain=${domain#https://*}

--- a/images/pixelfed/tests/e2e.sh
+++ b/images/pixelfed/tests/e2e.sh
@@ -2,6 +2,9 @@
 
 set -o errexit -o nounset -o pipefail
 
+echo "==> Checking environment requirements"
+scripts/check-requirements
+
 echo "==> Copying .env file"
 cp -v .env.docker .env
 

--- a/scripts/check-requirements
+++ b/scripts/check-requirements
@@ -12,7 +12,10 @@ source "${project_root}/scripts/lib/shared.sh"
 # Configuration
 #
 
-declare -r min_docker_compose_version_arr=(2 17)
+declare -r min_docker_compose_version_arr=(
+    2
+    20 # required by depends_on.required (https://docs.docker.com/compose/compose-file/05-services/#depends_on)
+)
 min_docker_compose_version=$(
     IFS=.
     echo "${min_docker_compose_version[*]}"


### PR DESCRIPTION
Using `depends_on.required = false` you can now opt-out of Redis and DB service without *breaking* the docker compose config file. 

Instead you will just receive a warning about the service being disabled.

Breaking change is the requirement for Docker Compose `2.20` instead of `2.17`, since `depends_on.required` was added in `2.20` 

fixes #34