### PR TITLE
Rework ENTRYPOINT locking and remove ngrok for End-to-End testing

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -430,7 +430,7 @@ DB_VERSION="11.4"
 DB_CONNECTION="mysql"
 
 # @see https://docs.pixelfed.org/technical-documentation/config/#db_host
-# @dottie/validate required,hostname
+# @dottie/validate required
 DB_HOST="db"
 
 # @see https://docs.pixelfed.org/technical-documentation/config/#db_username
@@ -870,7 +870,7 @@ SESSION_DRIVER="redis"
 #
 # @default the value of APP_DOMAIN, or null.
 # @see https://docs.pixelfed.org/technical-documentation/config/#session_domain
-# @dottie/validate hostname
+# @dottie/validate required
 #SESSION_DOMAIN="${APP_DOMAIN}"
 
 ################################################################################

--- a/.env.docker
+++ b/.env.docker
@@ -26,7 +26,7 @@ APP_NAME=""
 #
 # @see https://docs.pixelfed.org/technical-documentation/config/#app_domain
 # @dottie/example pixelfed.org
-# @dottie/validate required,ne=pixelfed.org,fqdn
+# @dottie/validate required,ne=pixelfed.org
 APP_DOMAIN=""
 
 # This URL is used by the console to properly generate URLs when using the Artisan command line tool.
@@ -41,7 +41,7 @@ APP_URL="https://${APP_DOMAIN}"
 #
 # @default ${APP_DOMAIN}
 # @see https://docs.pixelfed.org/technical-documentation/config/#admin_domain
-# @dottie/validate required,fqdn
+# @dottie/validate required
 ADMIN_DOMAIN="${APP_DOMAIN}"
 
 # This value determines the “environment” your application is currently running in.
@@ -487,7 +487,7 @@ DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY="false"
 #
 # @default smtp.mailgun.org
 # @see https://docs.pixelfed.org/technical-documentation/config/#mail_host
-# @dottie/validate required_with=MAIL_DRIVER,fqdn
+# @dottie/validate required_with=MAIL_DRIVER
 #MAIL_HOST="smtp.mailgun.org"
 
 # This is the SMTP port used by your application to deliver e-mails to users of the application.
@@ -1368,7 +1368,7 @@ DOCKER_PROXY_HOST_DOCKER_SOCKET_PATH="/var/run/docker.sock"
 # The host to request LetsEncrypt certificate for
 #
 # @default ${APP_DOMAIN}
-# @dottie/validate required,fqdn
+# @dottie/validate required
 DOCKER_PROXY_LETSENCRYPT_HOST="${APP_DOMAIN}"
 
 # The e-mail to use for Lets Encrypt certificate requests.

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -93,6 +93,8 @@ jobs:
           # !NOTE: we don't push cache here since its tags-only workflow
           cache-from: |
             type=gha,scope=php/branch/main/${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
+          cache-to: |
+            type=gha,mode=max,ignore-error=true,scope=php/branch/main/${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
 
   pixelfed:
     name: pixelfed
@@ -205,3 +207,5 @@ jobs:
           # !NOTE: we don't push cache here since its tags-only workflow
           cache-from: |
             type=gha,scope=pixelfed/branch/main/${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
+          cache-to: |
+            type=gha,mode=max,ignore-error=true,scope=pixelfed/branch/main/${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -11,12 +11,13 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+    branches:
+      - "main"
 
   # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
   push:
     branches:
-      - "*"
-      - "**"
+      - "main"
 
   # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
   # pull_request:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,8 +1,16 @@
-name: Docker
+name: Docker Test
 
 on:
   # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
   workflow_dispatch:
+
+  # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
   # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
   push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -135,10 +135,6 @@ jobs:
           # Cache from 'main' branch and the current branch, e.x., 'my-cool-branch'
           cache-from: |
             type=gha,scope=php/branch/main/${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
-            type=gha,scope=php/branch/${{ github.ref_name }}/${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
-          # Cache to the branch specific cache (e.x., 'my-cool-branch')
-          cache-to: |
-            type=gha,mode=max,ignore-error=true,scope=php/branch/${{ github.ref_name }}/${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
 
   pixelfed:
     name: pixelfed
@@ -243,13 +239,9 @@ jobs:
             PHP_VERSION=${{ matrix.php_version }}
             PHP_BASE_TYPE=${{ matrix.php_base }}
             PHP_DEBIAN_RELEASE=${{ matrix.debian_release }}
-          # Cache from 'main' branch and the current branch name, e.x., 'my-cool-branch'
+          # Cache from 'main' branch
           cache-from: |
             type=gha,scope=pixelfed/branch/main/${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
-            type=gha,scope=pixelfed/branch/${{ github.ref_name }}/${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
-          # Cache to the branch cache version (e.x., 'my-cool-branch')
-          cache-to: |
-            type=gha,mode=max,ignore-error=true,scope=pixelfed/branch/${{ github.ref_name }}/${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
 
       # goss validate the image
       #

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,7 +72,7 @@ jobs:
           - bookworm
         php_base:
           - apache
-          - fpm
+          # - fpm
 
     # See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-concurrency-and-the-default-behavior
     concurrency:
@@ -153,16 +153,16 @@ jobs:
         php_version:
           - 8.3
         pixelfed_branch:
-          - staging
+          # - staging
           - dev
         debian_release:
           - bookworm
         php_base:
           - apache
-          - fpm
+          # - fpm
         target_runtime:
           - apache
-          - nginx
+          # - nginx
 
         # See: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#excluding-matrix-configurations
         # See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixexclude

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -153,7 +153,7 @@ jobs:
         php_version:
           - 8.3
         pixelfed_branch:
-          # - staging
+          - staging
           - dev
         debian_release:
           - bookworm
@@ -266,31 +266,31 @@ jobs:
           DOCKER_APP_PHP_VERSION: ${{ matrix.php_version }}
           PHP_BASE_TYPE: ${{ matrix.php_base }}
 
-      - if: matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'dev'
+      - if: matrix.target_runtime == 'apache'
         name: "Setup NodeJS"
         uses: actions/setup-node@v4
         with:
           cache: "npm"
           cache-dependency-path: "package-lock.json"
 
-      - if: matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'dev'
+      - if: matrix.target_runtime == 'apache'
         name: Run E2E tests
         run: images/pixelfed/tests/e2e.sh
         env:
           CI: true
           DOCKER_APP_TAG: "${{ steps.meta.outputs.version }}"
 
-      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'dev'
+      - if: always() && matrix.target_runtime == 'apache'
         name: Show docker compose config
         run: docker compose config
 
-      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'dev'
+      - if: always() && matrix.target_runtime == 'apache'
         name: Show docker compose logs
         run: |
           docker compose logs
           docker compose down -v
 
-      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'dev'
+      - if: always() && matrix.target_runtime == 'apache'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report-${{ matrix.target_runtime }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -288,6 +288,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
+          name: playwright-report-${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
           path: test-results/
           retention-days: 30

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -270,15 +270,18 @@ jobs:
           CI: true
           DOCKER_APP_TAG: "${{ steps.meta.outputs.version }}"
 
-      - name: Show docker compose config
+      - if: always()
+        name: Show docker compose config
         run: docker compose config
 
-      - name: Show docker compose logs
+      - if: always()
+        name: Show docker compose logs
         run: |
           docker compose logs
           docker compose down -v
 
-      - uses: actions/upload-artifact@v4
+      - if: always()
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report-${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
           path: test-results/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -266,31 +266,31 @@ jobs:
           DOCKER_APP_PHP_VERSION: ${{ matrix.php_version }}
           PHP_BASE_TYPE: ${{ matrix.php_base }}
 
-      - if: matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
+      - if: matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'dev'
         name: "Setup NodeJS"
         uses: actions/setup-node@v4
         with:
           cache: "npm"
           cache-dependency-path: "package-lock.json"
 
-      - if: matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
+      - if: matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'dev'
         name: Run E2E tests
         run: images/pixelfed/tests/e2e.sh
         env:
           CI: true
           DOCKER_APP_TAG: "${{ steps.meta.outputs.version }}"
 
-      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
+      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'dev'
         name: Show docker compose config
         run: docker compose config
 
-      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
+      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'dev'
         name: Show docker compose logs
         run: |
           docker compose logs
           docker compose down -v
 
-      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
+      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'dev'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report-${{ matrix.target_runtime }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -279,13 +279,6 @@ jobs:
         env:
           CI: true
           DOCKER_APP_TAG: "${{ steps.meta.outputs.version }}"
-          NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
-
-      - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
-        name: Show ngrok logs
-        run: |
-          docker logs ngrok
-          docker rm -f ngrok
 
       - if: always() && matrix.target_runtime == 'apache' && matrix.pixelfed_branch == 'staging'
         name: Show docker compose config

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,7 +72,7 @@ jobs:
           - bookworm
         php_base:
           - apache
-          # - fpm
+          - fpm
 
     # See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-concurrency-and-the-default-behavior
     concurrency:
@@ -159,10 +159,10 @@ jobs:
           - bookworm
         php_base:
           - apache
-          # - fpm
+          - fpm
         target_runtime:
           - apache
-          # - nginx
+          - nginx
 
         # See: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#excluding-matrix-configurations
         # See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixexclude
@@ -266,33 +266,28 @@ jobs:
           DOCKER_APP_PHP_VERSION: ${{ matrix.php_version }}
           PHP_BASE_TYPE: ${{ matrix.php_base }}
 
-      - if: matrix.target_runtime == 'apache'
-        name: "Setup NodeJS"
+      - name: "Setup NodeJS"
         uses: actions/setup-node@v4
         with:
           cache: "npm"
           cache-dependency-path: "package-lock.json"
 
-      - if: matrix.target_runtime == 'apache'
-        name: Run E2E tests
+      - name: Run E2E tests
         run: images/pixelfed/tests/e2e.sh
         env:
           CI: true
           DOCKER_APP_TAG: "${{ steps.meta.outputs.version }}"
 
-      - if: always() && matrix.target_runtime == 'apache'
-        name: Show docker compose config
+      - name: Show docker compose config
         run: docker compose config
 
-      - if: always() && matrix.target_runtime == 'apache'
-        name: Show docker compose logs
+      - name: Show docker compose logs
         run: |
           docker compose logs
           docker compose down -v
 
-      - if: always() && matrix.target_runtime == 'apache'
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-${{ matrix.target_runtime }}
+          name: playwright-report-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
           path: test-results/
           retention-days: 30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,6 +188,7 @@ services:
       - "${DOCKER_ALL_HOST_CONFIG_ROOT_PATH}/proxy/conf.d:/shared/proxy/conf.d"
       - "${DOCKER_APP_HOST_CACHE_PATH}:/var/www/bootstrap/cache"
       - "${DOCKER_APP_HOST_OVERRIDES_PATH}:/docker/overrides:ro"
+      - "${DOCKER_APP_HOST_STORAGE_PATH}:/var/www/storage"
     depends_on:
       - db
       - redis

--- a/images/pixelfed/playwright.config.ts
+++ b/images/pixelfed/playwright.config.ts
@@ -25,10 +25,5 @@ export default defineConfig({
 
         // Whether to automatically capture a screenshot after each test. Defaults to 'off'.
         screenshot: 'on',
-
-        // https://playwright.dev/docs/api/class-testoptions#test-options-extra-http-headers
-        extraHTTPHeaders: {
-            'ngrok-skip-browser-warning': 'true',
-        },
     },
 })

--- a/images/pixelfed/playwright.config.ts
+++ b/images/pixelfed/playwright.config.ts
@@ -24,6 +24,6 @@ export default defineConfig({
         trace: 'on',
 
         // Whether to automatically capture a screenshot after each test. Defaults to 'off'.
-        screenshot: 'on',
+        screenshot: 'off',
     },
 })

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/01-permissions.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/01-permissions.sh
@@ -11,6 +11,7 @@ entrypoint-set-script-name "$0"
 run-as-current-user chown --verbose "${RUNTIME_UID}:${RUNTIME_GID}" "./.env"
 run-as-current-user chown --verbose "${RUNTIME_UID}:${RUNTIME_GID}" "./bootstrap/cache"
 run-as-current-user chown --verbose "${RUNTIME_UID}:${RUNTIME_GID}" "./storage"
+ensure-directory-exists "./storage/docker"
 run-as-current-user chown --verbose --recursive "${RUNTIME_UID}:${RUNTIME_GID}" "./storage/docker"
 
 # Optionally fix ownership of configured paths

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/04-defaults.envsh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/04-defaults.envsh
@@ -2,7 +2,7 @@
 
 # NOTE:
 #
-# This file is *sourced* not run by the entrypoint runner
+# This file is *sourced* not *run* by the entrypoint runner (thanks to the .envsh extension)
 # so any environment values set here will be accessible to all sub-processes
 # and future entrypoint.d scripts
 #

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/05-templating.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/05-templating.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
+# shellcheck source=SCRIPTDIR/../helpers.sh
+
 : "${ENTRYPOINT_ROOT:="/docker"}"
 
-# shellcheck source=SCRIPTDIR/../helpers.sh
 source "${ENTRYPOINT_ROOT}/helpers.sh"
 
 entrypoint-set-script-name "$0"
+
+# ! This file do not need a "lock" since it operates exclusively
+# ! within its own isolated container filesystem
 
 # Show [git diff] of templates being rendered (will help verify output)
 : "${ENTRYPOINT_SHOW_TEMPLATE_DIFF:=1}"
@@ -15,7 +19,6 @@ entrypoint-set-script-name "$0"
 
 declare template_file relative_template_file_path output_file_dir
 
-# load all dot-env config files
 load-and-export-config-files
 
 find "${ENTRYPOINT_TEMPLATE_DIR}" -follow -type f -print | while read -r template_file; do

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/10-storage.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/10-storage.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
+# shellcheck disable=SC2119
+
 : "${ENTRYPOINT_ROOT:="/docker"}"
 
 # shellcheck source=SCRIPTDIR/../helpers.sh
 source "${ENTRYPOINT_ROOT}/helpers.sh"
 
 entrypoint-set-script-name "$0"
+
+acquire-lock
 
 # Copy the [storage/] skeleton files over the "real" [storage/] directory so assets are updated between versions
 run-as-runtime-user cp --force --recursive storage.skel/. ./storage/

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/11-first-time-setup.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/11-first-time-setup.sh
@@ -18,6 +18,8 @@ if is-false "${DOCKER_APP_RUN_ONE_TIME_SETUP_TASKS}"; then
     exit 0
 fi
 
+acquire-lock
+
 await-database-ready
 
 # Following https://docs.pixelfed.org/running-pixelfed/installation/#one-time-setup-tasks

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/11-first-time-setup.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/11-first-time-setup.sh
@@ -18,6 +18,7 @@ if is-false "${DOCKER_APP_RUN_ONE_TIME_SETUP_TASKS}"; then
     exit 0
 fi
 
+# shellcheck disable=SC2119
 acquire-lock
 
 await-database-ready

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/11-first-time-setup.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/11-first-time-setup.sh
@@ -20,9 +20,11 @@ if is-false "${DOCKER_APP_RUN_ONE_TIME_SETUP_TASKS}"; then
     exit 0
 fi
 
-acquire-lock
-
+# Wait for the database to be ready
 await-database-ready
+
+# Make sure only one container run the remainder of this script at a time
+acquire-lock
 
 # Following https://docs.pixelfed.org/running-pixelfed/installation/#one-time-setup-tasks
 #

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/11-first-time-setup.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/11-first-time-setup.sh
@@ -40,5 +40,3 @@ fi
 if is-true "${OAUTH_ENABLED:-false}"; then
     only-once "passport:keys" run-as-runtime-user php artisan passport:keys
 fi
-
-release-lock

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/11-first-time-setup.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/11-first-time-setup.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC2119
+
 : "${ENTRYPOINT_ROOT:="/docker"}"
 
 # shellcheck source=SCRIPTDIR/../helpers.sh
@@ -18,7 +20,6 @@ if is-false "${DOCKER_APP_RUN_ONE_TIME_SETUP_TASKS}"; then
     exit 0
 fi
 
-# shellcheck disable=SC2119
 acquire-lock
 
 await-database-ready
@@ -39,3 +40,5 @@ fi
 if is-true "${OAUTH_ENABLED:-false}"; then
     only-once "passport:keys" run-as-runtime-user php artisan passport:keys
 fi
+
+release-lock

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/12-migrations.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/12-migrations.sh
@@ -28,8 +28,6 @@ echo "$output" | grep No && new_migrations=1
 if is-false "${new_migrations}"; then
     log-info "No new migrations detected"
 
-    release-lock
-
     exit 0
 fi
 
@@ -42,11 +40,7 @@ if is-false "${DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY}"; then
     log-info "Automatic applying of new database migrations is disabled"
     log-info "Please set [DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY=1] in your [.env] file to enable this."
 
-    release-lock
-
     exit 0
 fi
 
 run-as-runtime-user php artisan migrate --force
-
-release-lock

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/12-migrations.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/12-migrations.sh
@@ -9,6 +9,7 @@ entrypoint-set-script-name "$0"
 # Allow automatic applying of outstanding/new migrations on startup
 : "${DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY:=0}"
 
+# shellcheck disable=SC2119
 acquire-lock
 
 # Wait for the database to be ready

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/12-migrations.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/12-migrations.sh
@@ -28,6 +28,8 @@ echo "$output" | grep No && new_migrations=1
 if is-false "${new_migrations}"; then
     log-info "No new migrations detected"
 
+    release-lock
+
     exit 0
 fi
 

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/12-migrations.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/12-migrations.sh
@@ -11,10 +11,11 @@ entrypoint-set-script-name "$0"
 # Allow automatic applying of outstanding/new migrations on startup
 : "${DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY:=0}"
 
-acquire-lock
-
 # Wait for the database to be ready
 await-database-ready
+
+# Make sure only one container run the remainder of this script at a time
+acquire-lock
 
 # Run the migrate:status command and capture output
 output=$(run-as-runtime-user php artisan migrate:status || :)

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/12-migrations.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/12-migrations.sh
@@ -9,6 +9,8 @@ entrypoint-set-script-name "$0"
 # Allow automatic applying of outstanding/new migrations on startup
 : "${DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY:=0}"
 
+acquire-lock
+
 # Wait for the database to be ready
 await-database-ready
 

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/12-migrations.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.d/12-migrations.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC2119
+
 : "${ENTRYPOINT_ROOT:="/docker"}"
 
 # shellcheck source=SCRIPTDIR/../helpers.sh
@@ -9,7 +11,6 @@ entrypoint-set-script-name "$0"
 # Allow automatic applying of outstanding/new migrations on startup
 : "${DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY:=0}"
 
-# shellcheck disable=SC2119
 acquire-lock
 
 # Wait for the database to be ready
@@ -39,7 +40,11 @@ if is-false "${DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY}"; then
     log-info "Automatic applying of new database migrations is disabled"
     log-info "Please set [DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY=1] in your [.env] file to enable this."
 
+    release-lock
+
     exit 0
 fi
 
 run-as-runtime-user php artisan migrate --force
+
+release-lock

--- a/images/pixelfed/rootfs/shared/root/docker/entrypoint.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/entrypoint.sh
@@ -28,7 +28,7 @@ entrypoint-set-script-name "entrypoint.sh"
 # Convert ENTRYPOINT_SKIP_SCRIPTS into a native bash array for easier lookup
 declare -a skip_scripts
 # shellcheck disable=SC2034
-IFS=' ' read -r -a skip_scripts <<< "$ENTRYPOINT_SKIP_SCRIPTS"
+IFS=' ' read -r -a skip_scripts <<<"$ENTRYPOINT_SKIP_SCRIPTS"
 
 # Ensure the entrypoint root folder exists
 mkdir -p "${ENTRYPOINT_D_ROOT}"
@@ -45,8 +45,6 @@ if ! directory-is-empty "${DOCKER_APP_HOST_OVERRIDES_PATH}"; then
     log-info "Overrides directory is not empty, copying files"
     run-as-current-user cp --verbose --recursive "${DOCKER_APP_HOST_OVERRIDES_PATH}/." /
 fi
-
-acquire-lock "entrypoint.sh"
 
 # Start scanning for entrypoint.d files to source or run
 log-info "looking for shell scripts in [${ENTRYPOINT_D_ROOT}]"
@@ -97,8 +95,6 @@ find "${ENTRYPOINT_D_ROOT}" -follow -type f -print | sort -V | while read -r fil
             ;;
     esac
 done
-
-release-lock "entrypoint.sh"
 
 log-info "Configuration complete; ready for start up"
 

--- a/images/pixelfed/rootfs/shared/root/docker/helpers.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/helpers.sh
@@ -41,10 +41,12 @@ runtime_username=$(id -un "${RUNTIME_UID}")
 # @arg $1 string The name (or path) of the entrypoint script being run
 function entrypoint-set-script-name()
 {
-    script_name_previous="${script_name}"
-    script_name="${1}"
+    local -r new_script_name=$(get-entrypoint-script-name "$1")
 
-    log_prefix="[entrypoint / $(get-entrypoint-script-name "$1")] - "
+    script_name_previous="${script_name}"
+    script_name="${new_script_name}"
+
+    log_prefix="[entrypoint / ${new_script_name}] - "
 }
 
 # @description Restore the log prefix to the previous value that was captured in [entrypoint-set-script-name ]

--- a/images/pixelfed/rootfs/shared/root/docker/helpers.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/helpers.sh
@@ -422,7 +422,7 @@ function acquire-lock()
     return 0
 }
 
-# @description Release a lock aquired by [acquire-lock]
+# @description Release a lock acquired by [acquire-lock]
 # @arg $1 string The lock identifier
 function release-lock()
 {

--- a/images/pixelfed/rootfs/shared/root/docker/helpers.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/helpers.sh
@@ -392,7 +392,7 @@ function acquire-lock()
 
     ensure-directory-exists "$(dirname "${file}")"
 
-    log-info "🔐 Trying to acquire lock file [${file}]"
+    log-info "🔐 Trying to acquire lock file [${name}]"
 
     # poll for lock file up to ${time_max}s
     # put debugging info in lock file in case of issues ...
@@ -401,17 +401,17 @@ function acquire-lock()
         echo -e "DATE:$(date)\nUSER:$(whoami)\nPID:$$\nSERVICE:${DOCKER_SERVICE_NAME:-}" >"${file}"
     ) 2>/dev/null; do
         if [ $(($(date '+%s') - time_beg)) -gt "${time_max}" ]; then
-            log-error "🔐 Waited too long for lock file ${file}" 1>&2
+            log-error "🔐 Waited too long for lock file [${name}]" 1>&2
 
             return 1
         fi
 
-        log-info "🔐 Waiting for lock file [${file}] ..."
+        log-info "🔐 Waiting for lock file [${name}] ..."
 
         sleep 1
     done
 
-    log-info "🔐 Lock acquired [${file}]"
+    log-info "🔐 Lock acquired [${name}]"
 
     on-trap "release-lock ${name}" EXIT INT QUIT TERM
 

--- a/images/pixelfed/rootfs/shared/root/docker/helpers.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/helpers.sh
@@ -417,7 +417,7 @@ function acquire-lock()
 
     log-info "🔐 Lock acquired [${file}]"
 
-    on-trap "release-lock ${file}" EXIT INT QUIT TERM
+    on-trap "release-lock ${name}" EXIT INT QUIT TERM
 
     return 0
 }
@@ -430,6 +430,10 @@ function release-lock()
     local file="${docker_locks_path}/${name}"
 
     log-info "🔓 Releasing lock [${file}]"
+
+    if ! file-exists "$file"; then
+        log-warning "Lock file [${file}] does not exist - was a different name perhaps used in the call to [acquire-lock]?"
+    fi
 
     rm -f "${file}"
 }

--- a/images/pixelfed/rootfs/shared/root/docker/helpers.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/helpers.sh
@@ -173,7 +173,7 @@ function log-error()
         log-error-and-exit "[${FUNCNAME[0]}] did not receive any input arguments and STDIN is empty"
     fi
 
-    echo -e "$(date '+%Y-%m-%d %H:%M:%S %:z') ${error_message_color}${log_prefix}ERROR -${color_clear} ${msg}" >/dev/stderr
+    echo -e "$(date '+%Y-%m-%d %H:%M:%S %:z') - ${error_message_color}${log_prefix}ERROR -${color_clear} ${msg}" >/dev/stderr
 }
 
 # @description Print the given error message to stderr and exit 1
@@ -204,7 +204,7 @@ function log-warning()
         log-error-and-exit "[${FUNCNAME[0]}] did not receive any input arguments and STDIN is empty"
     fi
 
-    echo -e "$(date '+%Y-%m-%d %H:%M:%S %:z') ${warn_message_color}${log_prefix}WARNING -${color_clear} ${msg}" >/dev/stderr
+    echo -e "$(date '+%Y-%m-%d %H:%M:%S %:z') - ${warn_message_color}${log_prefix}WARNING -${color_clear} ${msg}" >/dev/stderr
 }
 
 # @description Print the given message to stdout unless [ENTRYPOINT_QUIET_LOGS] is set
@@ -223,7 +223,7 @@ function log-info()
     fi
 
     if [ -z "${ENTRYPOINT_QUIET_LOGS:-}" ]; then
-        echo -e "$(date '+%Y-%m-%d %H:%M:%S %:z') ${notice_message_color}${log_prefix}${color_clear}${msg}"
+        echo -e "$(date '+%Y-%m-%d %H:%M:%S %:z') - ${notice_message_color}${log_prefix}${color_clear}${msg}"
     fi
 }
 
@@ -243,7 +243,7 @@ function log-info-stderr()
     fi
 
     if [ -z "${ENTRYPOINT_QUIET_LOGS:-}" ]; then
-        echo -e "$(date '+%Y-%m-%d %H:%M:%S %:z') ${notice_message_color}${log_prefix}${color_clear}${msg}" >/dev/stderr
+        echo -e "$(date '+%Y-%m-%d %H:%M:%S %:z') - ${notice_message_color}${log_prefix}${color_clear}${msg}" >/dev/stderr
     fi
 }
 

--- a/images/pixelfed/rootfs/shared/root/docker/helpers.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/helpers.sh
@@ -402,15 +402,15 @@ function acquire-lock()
     # poll for lock file up to ${timeout_in_seconds}s
     while ! (
         set -o noclobber
-        echo -e "DATE:$(date)\nUSER:$(whoami)\nPID:$$\nSERVICE:${DOCKER_SERVICE_NAME:-}" >"${file}"
+        echo -e "[${DOCKER_SERVICE_NAME:-}] since [$(date)]" >"${file}"
     ) 2>/dev/null; do
         if [ $(($(date '+%s') - time_beg)) -gt "${timeout_in_seconds}" ]; then
-            log-error "🔐 Waited too long for lock file [${file}]" 1>&2
+            log-error "🔐 Waited too long for lock file [${file}]. Current lock is held by [$(cat "${file}")]" 1>&2
 
             return 1
         fi
 
-        log-info "🔐 Waiting for lock file [${file}] ..."
+        log-info "🔐 Waiting for lock file [${file}], currently held by [$(cat "${file}")]"
 
         sleep 1
     done

--- a/images/pixelfed/rootfs/shared/root/docker/helpers.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/helpers.sh
@@ -389,7 +389,7 @@ function acquire-lock()
 {
     local name="${1:-$script_name}"
     local file="${docker_locks_path}/${name}"
-    local -ir time_max="${2:-180}" # default timeout is 3 min
+    local -ir time_max="${2:-300}" # default timeout is 5 min
     local -ir time_beg=$(date '+%s')
 
     ensure-directory-exists "${docker_locks_path}"

--- a/images/pixelfed/rootfs/shared/root/docker/helpers.sh
+++ b/images/pixelfed/rootfs/shared/root/docker/helpers.sh
@@ -389,7 +389,7 @@ function acquire-lock()
 {
     local name="${1:-$script_name}"
     local file="${docker_locks_path}/${name}"
-    local -ir time_max="${2:-120}" # default timeout is 2 min
+    local -ir time_max="${2:-180}" # default timeout is 3 min
     local -ir time_beg=$(date '+%s')
 
     ensure-directory-exists "${docker_locks_path}"

--- a/images/pixelfed/tests/e2e.sh
+++ b/images/pixelfed/tests/e2e.sh
@@ -10,8 +10,12 @@ chmod -v 0777 .env
 
 app_domain="localhost"
 
+# We disable dottie validation since 'localhost' as APP_DOMAIN
+# is *technically* a misconfiguration
+
 echo "==> Reconfiguring .env file for testing"
 scripts/dottie set --no-validate \
+    ENTRYPOINT_SKIP_SCRIPTS="02-check-config.sh" \
     APP_DOMAIN="${app_domain}" \
     APP_NAME="docker-pixelfed e2e" \
     DB_PASSWORD="helloworld" \

--- a/images/pixelfed/tests/e2e.sh
+++ b/images/pixelfed/tests/e2e.sh
@@ -14,8 +14,7 @@ app_domain="localhost"
 # is *technically* a misconfiguration
 
 echo "==> Reconfiguring .env file for testing"
-scripts/dottie set --no-validate \
-    ENTRYPOINT_SKIP_SCRIPTS="02-check-config.sh" \
+scripts/dottie set \
     APP_DOMAIN="${app_domain}" \
     APP_NAME="docker-pixelfed e2e" \
     DB_PASSWORD="helloworld" \

--- a/images/pixelfed/tests/e2e.sh
+++ b/images/pixelfed/tests/e2e.sh
@@ -11,7 +11,7 @@ chmod -v 0777 .env
 app_domain="localhost"
 
 echo "==> Reconfiguring .env file for testing"
-scripts/dottie set \
+scripts/dottie set --no-validate \
     APP_DOMAIN="${app_domain}" \
     APP_NAME="docker-pixelfed e2e" \
     DB_PASSWORD="helloworld" \

--- a/images/pixelfed/tests/e2e.sh
+++ b/images/pixelfed/tests/e2e.sh
@@ -37,7 +37,7 @@ echo "==> Install playwright depdendencies"
 npx playwright install chromium --with-deps
 
 echo "==> Wait for the site to come up, while streaming the logs"
-curl --retry-delay 1 --retry 120 --retry-max-time 120 --retry-all-errors --fail -o /dev/null "http://${app_domain}:8080"
+curl --retry-delay 1 --retry 180 --retry-max-time 180 --retry-all-errors --fail -o /dev/null "http://${app_domain}:8080"
 
 echo "==> Run playwright tests"
 export E2E_URL="http://${app_domain}:8080"

--- a/images/pixelfed/tests/e2e.sh
+++ b/images/pixelfed/tests/e2e.sh
@@ -37,7 +37,7 @@ echo "==> Install playwright depdendencies"
 npx playwright install chromium --with-deps
 
 echo "==> Wait for the site to come up, while streaming the logs"
-curl --retry-delay 1 --retry 60 --retry-max-time 60 --retry-all-errors --fail -o /dev/null "http://${app_domain}"
+curl --retry-delay 1 --retry 120 --retry-max-time 120 --retry-all-errors --fail -o /dev/null "http://${app_domain}"
 
 echo "==> Run playwright tests"
 export E2E_URL="http://${app_domain}"

--- a/images/pixelfed/tests/e2e.sh
+++ b/images/pixelfed/tests/e2e.sh
@@ -37,8 +37,8 @@ echo "==> Install playwright depdendencies"
 npx playwright install chromium --with-deps
 
 echo "==> Wait for the site to come up, while streaming the logs"
-curl --retry-delay 1 --retry 120 --retry-max-time 120 --retry-all-errors --fail -o /dev/null "http://${app_domain}"
+curl --retry-delay 1 --retry 120 --retry-max-time 120 --retry-all-errors --fail -o /dev/null "http://${app_domain}:8080"
 
 echo "==> Run playwright tests"
-export E2E_URL="http://${app_domain}"
+export E2E_URL="http://${app_domain}:8080"
 exec npx playwright test --config images/pixelfed/playwright.config.ts

--- a/images/pixelfed/tests/e2e.sh
+++ b/images/pixelfed/tests/e2e.sh
@@ -8,19 +8,7 @@ cp -v .env.docker .env
 echo "==> Changing .env permissions"
 chmod -v 0777 .env
 
-echo "==> Starting ngrok"
-docker run --quiet --detach --name ngrok --env NGROK_AUTHTOKEN --net=host ngrok/ngrok http 8080
-
-echo "==> Following ngrok logs"
-docker logs ngrok -f &
-
-echo "==> Finding ngrok tunnel public URL"
-domain="$(curl --retry-all-errors --fail --retry 60 --retry-max-time 60 http://127.0.0.1:4040/api/tunnels | jq -r ".tunnels[0].public_url")"
-echo "OK: ${domain}"
-
-echo "==> Finding ngrok tunnel public host (domain without https://)"
-app_domain=${domain#https://*}
-echo "OK: ${app_domain}"
+app_domain="localhost"
 
 echo "==> Reconfiguring .env file for testing"
 scripts/dottie set \
@@ -45,8 +33,8 @@ echo "==> Install playwright depdendencies"
 npx playwright install chromium --with-deps
 
 echo "==> Wait for the site to come up, while streaming the logs"
-curl --header "ngrok-skip-browser-warning: true" --retry-delay 1 --retry 60 --retry-max-time 60 --retry-all-errors --fail -o /dev/null "${domain}"
+curl --retry-delay 1 --retry 60 --retry-max-time 60 --retry-all-errors --fail -o /dev/null "http://${app_domain}"
 
 echo "==> Run playwright tests"
-export E2E_URL="${domain}"
+export E2E_URL="http://${app_domain}"
 exec npx playwright test --config images/pixelfed/playwright.config.ts

--- a/images/pixelfed/tests/playwright/e2e.spec.ts
+++ b/images/pixelfed/tests/playwright/e2e.spec.ts
@@ -6,8 +6,8 @@ test('page should load without errors', async ({ page }) => {
     expect(page).toHaveTitle("docker-pixelfed e2e")
 })
 
-test('/api/nodeinfo/2.0.json', async ({ page }) => {
-    const response = await page.get('/api/nodeinfo/2.0.json')
+test('/api/nodeinfo/2.0.json', async ({ request }) => {
+    const response = await request.get('/api/nodeinfo/2.0.json')
     const json = JSON.parse(await response.text())
 
     expect(json.nodeName).toBe("docker-pixelfed e2e")
@@ -15,8 +15,8 @@ test('/api/nodeinfo/2.0.json', async ({ page }) => {
     expect(json.usage.users.total).toBe(0)
 })
 
-test('/api/v1/instance', async ({ page }) => {
-    const response = await page.get('/api/v1/instance')
+test('/api/v1/instance', async ({ request }) => {
+    const response = await request.get('/api/v1/instance')
     const json = JSON.parse(await response.text())
 
     expect(json.email).toBe("github@example.com")

--- a/images/pixelfed/tests/playwright/e2e.spec.ts
+++ b/images/pixelfed/tests/playwright/e2e.spec.ts
@@ -10,9 +10,11 @@ test('/api/nodeinfo/2.0.json', async ({ request }) => {
     const response = await request.get('/api/nodeinfo/2.0.json')
     const json = JSON.parse(await response.text())
 
-    expect(json.nodeName).toBe("docker-pixelfed e2e")
+    console.log({ json })
+
     expect(json.software.name).toBe("pixelfed")
     expect(json.usage.users.total).toBe(0)
+    expect(json.nodeName).toBe("docker-pixelfed e2e")
 })
 
 test('/api/v1/instance', async ({ request }) => {

--- a/images/pixelfed/tests/playwright/e2e.spec.ts
+++ b/images/pixelfed/tests/playwright/e2e.spec.ts
@@ -4,6 +4,11 @@ test('page should load without errors', async ({ page }) => {
     await page.goto('/')
 
     expect(page).toHaveTitle("docker-pixelfed e2e")
+
+    expect(page.locator('a', { hasText: 'Sign up' })).toBeVisible()
+    expect(page.locator('a', { hasText: 'Login' })).toBeVisible()
+    expect(page.locator('a', { hasText: 'Powered by Pixelfed' })).toBeVisible()
+    expect(page.locator('a.admin-email', { hasText: 'github@example.com' })).toBeVisible()
 })
 
 test('/api/nodeinfo/2.0.json', async ({ request }) => {
@@ -14,7 +19,7 @@ test('/api/nodeinfo/2.0.json', async ({ request }) => {
 
     expect(json.software.name).toBe("pixelfed")
     expect(json.usage.users.total).toBe(0)
-    expect(json.nodeName).toBe("docker-pixelfed e2e")
+    expect(json.metadata.nodeName).toBe("docker-pixelfed e2e")
 })
 
 test('/api/v1/instance', async ({ request }) => {

--- a/images/pixelfed/tests/playwright/e2e.spec.ts
+++ b/images/pixelfed/tests/playwright/e2e.spec.ts
@@ -2,7 +2,8 @@ import { test, expect } from '@playwright/test'
 
 test('page should load without errors', async ({ page }) => {
     await page.goto('/')
-    await page.waitForLoadState()
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForLoadState('networkidle')
 
     expect(page.locator('a', { hasText: 'Sign up' })).toBeVisible()
     expect(page.locator('a', { hasText: 'Login' })).toBeVisible()

--- a/images/pixelfed/tests/playwright/e2e.spec.ts
+++ b/images/pixelfed/tests/playwright/e2e.spec.ts
@@ -1,9 +1,24 @@
 import { test, expect } from '@playwright/test'
 
 test('page should load without errors', async ({ page }) => {
-    console.error("E2E_URL", process.env.E2E_URL)
-
     await page.goto('/')
 
     expect(page).toHaveTitle("docker-pixelfed e2e")
 })
+
+test('/api/nodeinfo/2.0.json', async ({ page }) => {
+    const response = await page.get('/api/nodeinfo/2.0.json')
+    const json = JSON.parse(await response.text())
+
+    expect(json.nodeName).toBe("docker-pixelfed e2e")
+    expect(json.software.name).toBe("pixelfed")
+    expect(json.usage.users.total).toBe(0)
+})
+
+test('/api/v1/instance', async ({ page }) => {
+    const response = await page.get('/api/v1/instance')
+    const json = JSON.parse(await response.text())
+
+    expect(json.email).toBe("github@example.com")
+})
+

--- a/images/pixelfed/tests/playwright/e2e.spec.ts
+++ b/images/pixelfed/tests/playwright/e2e.spec.ts
@@ -15,8 +15,6 @@ test('/api/nodeinfo/2.0.json', async ({ request }) => {
     const response = await request.get('/api/nodeinfo/2.0.json')
     const json = JSON.parse(await response.text())
 
-    console.log({ json })
-
     expect(json.software.name).toBe("pixelfed")
     expect(json.usage.users.total).toBe(0)
     expect(json.metadata.nodeName).toBe("docker-pixelfed e2e")

--- a/images/pixelfed/tests/playwright/e2e.spec.ts
+++ b/images/pixelfed/tests/playwright/e2e.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('page should load without errors', async ({ page }) => {
     await page.goto('/')
+    await page.waitForLoadState()
 
     expect(page).toHaveTitle("docker-pixelfed e2e")
 

--- a/images/pixelfed/tests/playwright/e2e.spec.ts
+++ b/images/pixelfed/tests/playwright/e2e.spec.ts
@@ -4,12 +4,12 @@ test('page should load without errors', async ({ page }) => {
     await page.goto('/')
     await page.waitForLoadState()
 
-    expect(page).toHaveTitle("docker-pixelfed e2e")
-
     expect(page.locator('a', { hasText: 'Sign up' })).toBeVisible()
     expect(page.locator('a', { hasText: 'Login' })).toBeVisible()
     expect(page.locator('a', { hasText: 'Powered by Pixelfed' })).toBeVisible()
     expect(page.locator('a.admin-email', { hasText: 'github@example.com' })).toBeVisible()
+
+    expect(page).toHaveTitle("docker-pixelfed e2e")
 })
 
 test('/api/nodeinfo/2.0.json', async ({ request }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "docker-pixelfed",
+    "name": "pixelfed",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
     "license": "MIT",
     "type": "module",
+    "volta": {
+        "node": "22.12.0"
+    },
     "devDependencies": {
         "@playwright/test": "1.49.1",
         "@types/node": "22.10.6",


### PR DESCRIPTION
* Add timestamp to log output for easier tracking of timeline of events
* Run End-to-End (E2E) tests for all runtimes
* Expand E2E tests for a couple of more endpoints
* Add missing `/var/www/storage` volume to `cron` service
* Remove global `entrypoint` lock in favor of more targeted ones where its required
* Change locking to use `noclobber` and file existence instead of file descriptor magic