### PR TITLE
Fix broken links in docs

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -17,14 +17,16 @@
 ################################################################################
 
 # The name/title for your site
-# @see https://docs.pixelfed.org/technical-documentation/config/#app_name-1
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-app-php
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#app-variables
 # @dottie/example My Pixelfed Site
 # @dottie/validate required,ne=My Pixelfed Site
 APP_NAME=""
 
 # Application domain used for routing. (e.g., pixelfed.org)
 #
-# @see https://docs.pixelfed.org/technical-documentation/config/#app_domain
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#app-variables
 # @dottie/example pixelfed.org
 # @dottie/validate required,ne=pixelfed.org
 APP_DOMAIN=""
@@ -33,14 +35,15 @@ APP_DOMAIN=""
 # You should set this to the root of your application so that it is used when running Artisan tasks.
 #
 # @default https://${APP_DOMAIN}
-# @see https://docs.pixelfed.org/technical-documentation/config/#app_url
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-app-php
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#app-variables
 # @dottie/validate required,http_url
 APP_URL="https://${APP_DOMAIN}"
 
 # Application domains used for routing.
 #
 # @default ${APP_DOMAIN}
-# @see https://docs.pixelfed.org/technical-documentation/config/#admin_domain
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#app-variables
 # @dottie/validate required
 ADMIN_DOMAIN="${APP_DOMAIN}"
 
@@ -48,7 +51,7 @@ ADMIN_DOMAIN="${APP_DOMAIN}"
 # This may determine how you prefer to configure various services your application utilizes.
 #
 # @default production
-# @see https://docs.pixelfed.org/technical-documentation/config/#app_env
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-app-php
 # @dottie/validate oneof=production dev staging
 #APP_ENV="production"
 
@@ -58,7 +61,7 @@ ADMIN_DOMAIN="${APP_DOMAIN}"
 # If disabled, a simple generic error page is shown.
 #
 # @default false
-# @see https://docs.pixelfed.org/technical-documentation/config/#app_debug
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#app-variables
 # @dottie/validate boolean
 #APP_DEBUG="false"
 
@@ -67,46 +70,46 @@ ADMIN_DOMAIN="${APP_DOMAIN}"
 # If disabled, settings must be managed by .env variables.
 #
 # @default true
-# @see https://docs.pixelfed.org/technical-documentation/config/#config_cache
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-instance-php
 # @dottie/validate boolean
 ENABLE_CONFIG_CACHE="true"
 
 # Enable/disable new local account registrations.
 #
 # @default true
-# @see https://docs.pixelfed.org/technical-documentation/config/#open_registration
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate boolean
 #OPEN_REGISTRATION="true"
 
 # Require email verification before a new user can do anything.
 #
 # @default true
-# @see https://docs.pixelfed.org/technical-documentation/config/#enforce_email_verification
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate boolean
 #ENFORCE_EMAIL_VERIFICATION="true"
 
 # Allow a maximum number of user accounts.
 #
 # @default 1000
-# @see https://docs.pixelfed.org/technical-documentation/config/#pf_max_users
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate number
 #PF_MAX_USERS="1000"
 
 # Enforce the maximum number of user accounts
 #
 # @default true
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate boolean
 #PF_ENFORCE_MAX_USERS="true"
 
 # @default false
-# @see https://docs.pixelfed.org/technical-documentation/config/#oauth_enabled
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate boolean
 #OAUTH_ENABLED="false"
 
 # !!! warning "Do not edit your timezone once the service is running - or things will break!"
 #
 # @default UTC
-# @see https://docs.pixelfed.org/technical-documentation/config/#app_timezone
 # @see https://www.php.net/manual/en/timezones.php
 # @dottie/validate required,timezone
 APP_TIMEZONE="UTC"
@@ -115,7 +118,7 @@ APP_TIMEZONE="UTC"
 # You are free to set this value to any of the locales which will be supported by the application.
 #
 # @default en
-# @see https://docs.pixelfed.org/technical-documentation/config/#app_locale
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-app-php
 #APP_LOCALE="en"
 
 # The fallback locale determines the locale to use when the current one is not available.
@@ -123,146 +126,142 @@ APP_TIMEZONE="UTC"
 # You may change the value to correspond to any of the language folders that are provided through your application.
 #
 # @default en
-# @see https://docs.pixelfed.org/technical-documentation/config/#app_fallback_locale
 #APP_FALLBACK_LOCALE="en"
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#limit_account_size
 # @dottie/validate boolean
 #LIMIT_ACCOUNT_SIZE="true"
 
 # Update the max account size, the per user limit of files in kB.
 #
 # @default 1000000 (1GB)
-# @see https://docs.pixelfed.org/technical-documentation/config/#max_account_size-kb
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate number
 #MAX_ACCOUNT_SIZE="1000000"
 
 # Update the max photo size, in kB.
 #
 # @default 15000 (15MB)
-# @see https://docs.pixelfed.org/technical-documentation/config/#max_photo_size-kb
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate number
 #MAX_PHOTO_SIZE="15000"
 
 # The max number of photos allowed per post.
 #
 # @default 4
-# @see https://docs.pixelfed.org/technical-documentation/config/#max_album_length
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate number
 #MAX_ALBUM_LENGTH="4"
 
 # Update the max avatar size, in kB.
 #
 # @default 2000 (2MB).
-# @see https://docs.pixelfed.org/technical-documentation/config/#max_avatar_size-kb
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate number
 #MAX_AVATAR_SIZE="2000"
 
 # Change the caption length limit for new local posts.
 #
 # @default 500
-# @see https://docs.pixelfed.org/technical-documentation/config/#max_caption_length
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate number
 #MAX_CAPTION_LENGTH="500"
 
 # Change the bio length limit for user profiles.
 #
 # @default 125
-# @see https://docs.pixelfed.org/technical-documentation/config/#max_bio_length
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate number
 #MAX_BIO_LENGTH="125"
 
 # Change the length limit for user names.
 #
 # @default 30
-# @see https://docs.pixelfed.org/technical-documentation/config/#max_name_length
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate number
 #MAX_NAME_LENGTH="30"
 
 # Resize and optimize image uploads.
 #
 # @default true
-# @see https://docs.pixelfed.org/technical-documentation/config/#pf_optimize_images
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate boolean
 #PF_OPTIMIZE_IMAGES="true"
 
 # Set the image optimization quality, must be a value between 1-100.
 #
 # @default 80
-# @see https://docs.pixelfed.org/technical-documentation/config/#image_quality
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate number
 #IMAGE_QUALITY="80"
 
 # Resize and optimize video uploads.
 #
 # @default true
-# @see https://docs.pixelfed.org/technical-documentation/config/#pf_optimize_videos
 # @dottie/validate boolean
 #PF_OPTIMIZE_VIDEOS="true"
 
 # Enable account deletion.
 #
 # @default true
-# @see https://docs.pixelfed.org/technical-documentation/config/#account_deletion
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate boolean
 #ACCOUNT_DELETION="true"
 
 # Set account deletion queue after X days, set to false to delete accounts immediately.
 #
 # @default false
-# @see https://docs.pixelfed.org/technical-documentation/config/#account_delete_after
 # @dottie/validate boolean|number
 #ACCOUNT_DELETE_AFTER="false"
 
 # @default Pixelfed - Photo sharing for everyone
-# @see https://docs.pixelfed.org/technical-documentation/config/#instance_description
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-instance-php
 #INSTANCE_DESCRIPTION=""
 
 # @default false
-# @see https://docs.pixelfed.org/technical-documentation/config/#instance_public_hashtags
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-instance-php
 # @dottie/validate boolean
 #INSTANCE_PUBLIC_HASHTAGS="false"
 
 # The public e-mail address people can use to contact you by
 #
 # @default
-# @see https://docs.pixelfed.org/technical-documentation/config/#instance_contact_email
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-instance-php
 # @dottie/validate required,ne=__CHANGE_ME__,email
 INSTANCE_CONTACT_EMAIL="__CHANGE_ME__"
 
 # @default false
-# @see https://docs.pixelfed.org/technical-documentation/config/#instance_public_local_timeline
 # @dottie/validate boolean
 #INSTANCE_PUBLIC_LOCAL_TIMELINE="false"
 
 # @default false
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-instance-php
 # @dottie/validate boolean
 #INSTANCE_REPORTS_EMAIL_ENABLED="false"
 
 # Send email reports for auto-spam detections to this e-mail
 #
 # @default ""
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-instance-php
 #INSTANCE_REPORTS_EMAIL_ADDRESSES="your@email.example"
 
 # Send email reports on 'autospam'
 #
 # @default false
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-instance-php
 # @dottie/validate boolean
 #INSTANCE_REPORTS_EMAIL_AUTOSPAM="false"
 
 # @default
-# @see https://docs.pixelfed.org/technical-documentation/config/#banned_usernames
 #BANNED_USERNAMES=""
 
 # @default false
-# @see https://docs.pixelfed.org/technical-documentation/config/#stories_enabled
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-instance-php
 # @dottie/validate boolean
 #STORIES_ENABLED="false"
 
 # Level is hardcoded to 1.
 #
 # @default false
-# @see https://docs.pixelfed.org/technical-documentation/config/#restricted_instance
 # @dottie/validate boolean
 #RESTRICTED_INSTANCE="false"
 
@@ -322,7 +321,6 @@ INSTANCE_CONTACT_EMAIL="__CHANGE_ME__"
 #PF_IMPORT_IG_PERM_ONLY_USER_IDS=""
 
 # @default false
-# @see https://docs.pixelfed.org/technical-documentation/config/#media_exif_database
 # @dottie/validate boolean
 #MEDIA_EXIF_DATABASE="false"
 
@@ -334,7 +332,7 @@ INSTANCE_CONTACT_EMAIL="__CHANGE_ME__"
 # * imagick
 #
 # @default gd
-# @see https://docs.pixelfed.org/technical-documentation/config/#image_driver
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#additional-variables
 # @dottie/validate oneof=gd imagick
 #IMAGE_DRIVER="gd"
 
@@ -353,7 +351,6 @@ INSTANCE_CONTACT_EMAIL="__CHANGE_ME__"
 # that client’s request has subsequently passed through.
 #
 # @default *
-# @see https://docs.pixelfed.org/technical-documentation/config/#trust_proxies
 #TRUST_PROXIES="*"
 
 # This option controls the default cache connection that gets used while using this caching library.
@@ -370,12 +367,11 @@ INSTANCE_CONTACT_EMAIL="__CHANGE_ME__"
 # * redis
 #
 # @default file
-# @see https://docs.pixelfed.org/technical-documentation/config/#cache_driver
+# @see https://docs.pixelfed.org/cumentation/config/#cache_driver
 # @dottie/validate required,oneof=apc array database file memcached redis
 CACHE_DRIVER="redis"
 
 # @default ${APP_NAME}_cache, or laravel_cache if no APP_NAME is set.
-# @see https://docs.pixelfed.org/technical-documentation/config/#cache_prefix
 #CACHE_PREFIX="{APP_NAME}_cache"
 
 # This option controls the default broadcaster that will be used by the framework when an event needs to be broadcast.
@@ -387,12 +383,10 @@ CACHE_DRIVER="redis"
 # * log
 # * null
 #
-# @see https://docs.pixelfed.org/technical-documentation/config/#broadcast_driver
 # @dottie/validate oneof=pusher redis log null
 BROADCAST_DRIVER="redis"
 
 # @default true
-# @see https://docs.pixelfed.org/technical-documentation/config/#restrict_html_types
 # @dottie/validate boolean
 #RESTRICT_HTML_TYPES="true"
 
@@ -402,11 +396,9 @@ BROADCAST_DRIVER="redis"
 # By default, the keys are stored as local files but can be set via environment
 # variables when that is more convenient.
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#passport_private_key
 # @dottie/validate required
 #PASSPORT_PRIVATE_KEY=""
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#passport_public_key
 # @dottie/validate required
 #PASSPORT_PUBLIC_KEY=""
 
@@ -417,6 +409,7 @@ BROADCAST_DRIVER="redis"
 # Enable or disable curated onboarding
 #
 # @default false
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-instance-php
 # @dottie/validate boolean
 #INSTANCE_CUR_REG="false"
 
@@ -481,32 +474,32 @@ DB_VERSION="11.4"
 # * pgsql
 # * sqlsrv
 #
-# @see https://docs.pixelfed.org/technical-documentation/config/#db_connection
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#database-variables
 # @dottie/validate required,oneof=sqlite mysql pgsql sqlsrv
 DB_CONNECTION="mysql"
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#db_host
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#database-variables
 # @dottie/validate required
 DB_HOST="db"
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#db_username
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#database-variables
 # @dottie/validate required
 DB_USERNAME="pixelfed"
 
 # The password to your database. Please make it secure.
 # Use a site like https://pwgen.io/ to generate it
 #
-# @see https://docs.pixelfed.org/technical-documentation/config/#db_password
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#database-variables
 # @dottie/validate required,ne=__CHANGE_ME__
 DB_PASSWORD="__CHANGE_ME__"
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#db_database
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#database-variables
 # @dottie/validate required
 DB_DATABASE="pixelfed_prod"
 
 # Use "3306" for MySQL/MariaDB and "5432" for PostgreeSQL
 #
-# @see https://docs.pixelfed.org/technical-documentation/config/#db_port
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#database-variables
 # @dottie/validate required,number
 DB_PORT=3306
 
@@ -533,7 +526,7 @@ DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY="false"
 # * array
 #
 # @default smtp
-# @see https://docs.pixelfed.org/technical-documentation/config/#mail_driver
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#email-variables
 # @dottie/validate oneof=smtp sendmail mailgun mandrill ses sparkpost log array
 #MAIL_DRIVER="smtp"
 
@@ -542,7 +535,7 @@ DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY="false"
 # A default option is provided that is compatible with the Mailgun mail service which will provide reliable deliveries.
 #
 # @default smtp.mailgun.org
-# @see https://docs.pixelfed.org/technical-documentation/config/#mail_host
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#email-variables
 # @dottie/validate required_with=MAIL_DRIVER
 #MAIL_HOST="smtp.mailgun.org"
 
@@ -551,7 +544,7 @@ DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY="false"
 # Like the host we have set this value to stay compatible with the Mailgun e-mail application by default.
 #
 # @default 587.
-# @see https://docs.pixelfed.org/technical-documentation/config/#mail_port
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#email-variables
 # @dottie/validate required_with=MAIL_DRIVER,number
 #MAIL_PORT="587"
 
@@ -560,14 +553,14 @@ DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY="false"
 # You may wish for all e-mails sent by your application to be sent from the same address.
 #
 # @default bot@example.com
-# @see https://docs.pixelfed.org/technical-documentation/config/#mail_from_address
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#email-variables
 # @dottie/validate required_with=MAIL_DRIVER,email,ne=__CHANGE_ME__
 #MAIL_FROM_ADDRESS="__CHANGE_ME__"
 
 # The 'name' you send e-mail from
 #
 # @default Example
-# @see https://docs.pixelfed.org/technical-documentation/config/#mail_from_name
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#email-variables
 # @dottie/validate required_with=MAIL_DRIVER
 #MAIL_FROM_NAME="${APP_NAME}"
 
@@ -577,12 +570,12 @@ DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY="false"
 # You may also set the “password” value below this one.
 #
 # @default
-# @see https://docs.pixelfed.org/technical-documentation/config/#mail_username
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#email-variables
 # @dottie/validate required_with=MAIL_DRIVER
 #MAIL_USERNAME=""
 
 # @default
-# @see https://docs.pixelfed.org/technical-documentation/config/#mail_password
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#email-variables
 # @dottie/validate required_with=MAIL_DRIVER
 #MAIL_PASSWORD=""
 
@@ -591,7 +584,7 @@ DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY="false"
 # A sensible default using the transport layer security protocol should provide great security.
 #
 # @default tls
-# @see https://docs.pixelfed.org/technical-documentation/config/#mail_encryption
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#email-variables
 # @dottie/validate required_with=MAIL_DRIVER
 #MAIL_ENCRYPTION="tls"
 
@@ -600,29 +593,27 @@ DB_APPLY_NEW_MIGRATIONS_AUTOMATICALLY="false"
 ################################################################################
 
 # @default phpredis
-# @see https://docs.pixelfed.org/technical-documentation/config/#redis_client
 #REDIS_CLIENT="phpredis"
 
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#database-variables
 # @default tcp
-# @see https://docs.pixelfed.org/technical-documentation/config/#redis_scheme
 #REDIS_SCHEME="tcp"
 
 # @default localhost
-# @see https://docs.pixelfed.org/technical-documentation/config/#redis_host
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#database-variables
 # @dottie/validate required
 REDIS_HOST="redis"
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#redis_password
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#database-variables
 # @dottie/validate omitempty
 #REDIS_PASSWORD=
 
 # @default 6379
-# @see https://docs.pixelfed.org/technical-documentation/config/#redis_port
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#database-variables
 # @dottie/validate required,number
 REDIS_PORT="6379"
 
 # @default 0
-# @see https://docs.pixelfed.org/technical-documentation/config/#redis_database
 # @dottie/validate number
 #REDIS_DATABASE="0"
 
@@ -633,28 +624,24 @@ REDIS_PORT="6379"
 # Text only posts (alpha).
 #
 # @default false
-# @see https://docs.pixelfed.org/technical-documentation/config/#exp_top
 # @dottie/validate boolean
 #EXP_TOP="false"
 
 # Poll statuses (alpha).
 #
 # @default false
-# @see https://docs.pixelfed.org/technical-documentation/config/#exp_polls
 # @dottie/validate boolean
 #EXP_POLLS="false"
 
 # Cached public timeline for larger instances (beta).
 #
 # @default false
-# @see https://docs.pixelfed.org/technical-documentation/config/#exp_cpt
 # @dottie/validate boolean
 #EXP_CPT="false"
 
 # Enforce Mastodon API Compatibility (alpha).
 #
 # @default true
-# @see https://docs.pixelfed.org/technical-documentation/config/#exp_emc
 # @dottie/validate boolean
 #EXP_EMC="true"
 
@@ -663,27 +650,24 @@ REDIS_PORT="6379"
 ################################################################################
 
 # @default false
-# @see https://docs.pixelfed.org/technical-documentation/config/#activity_pub
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#additional-variables
 # @dottie/validate boolean
 #ACTIVITY_PUB="true"
 
 # @default true
-# @see https://docs.pixelfed.org/technical-documentation/config/#ap_remote_follow
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#additional-variables
 # @dottie/validate boolean
 #AP_REMOTE_FOLLOW="true"
 
 # @default true
-# @see https://docs.pixelfed.org/technical-documentation/config/#ap_sharedinbox
 # @dottie/validate boolean
 #AP_SHAREDINBOX="true"
 
 # @default true
-# @see https://docs.pixelfed.org/technical-documentation/config/#ap_inbox
 # @dottie/validate boolean
 #AP_INBOX="true"
 
 # @default true
-# @see https://docs.pixelfed.org/technical-documentation/config/#ap_outbox
 # @dottie/validate boolean
 #AP_OUTBOX="true"
 
@@ -692,17 +676,14 @@ REDIS_PORT="6379"
 ################################################################################
 
 # @default true
-# @see https://docs.pixelfed.org/technical-documentation/config/#atom_feeds
 # @dottie/validate boolean
 #ATOM_FEEDS="true"
 
 # @default true
-# @see https://docs.pixelfed.org/technical-documentation/config/#nodeinfo
 # @dottie/validate boolean
 #NODEINFO="true"
 
 # @default true
-# @see https://docs.pixelfed.org/technical-documentation/config/#webfinger
 # @dottie/validate boolean
 #WEBFINGER="true"
 
@@ -713,7 +694,7 @@ REDIS_PORT="6379"
 # Store media on object storage like S3, Digital Ocean Spaces, Rackspace
 #
 # @default false
-# @see https://docs.pixelfed.org/technical-documentation/config/#pf_enable_cloud
+# @see https://docs.pixelfed.org/running-pixelfed/configuration.html#config-pixelfed-php
 # @dottie/validate boolean
 #PF_ENABLE_CLOUD="false"
 
@@ -723,40 +704,31 @@ REDIS_PORT="6379"
 # This driver will be bound as the Cloud disk implementation in the container.
 #
 # @default s3
-# @see https://docs.pixelfed.org/technical-documentation/config/#filesystem_cloud
 # @dottie/validate required_with=PF_ENABLE_CLOUD
 #FILESYSTEM_CLOUD="s3"
 
 # @default true.
-# @see https://docs.pixelfed.org/technical-documentation/config/#media_delete_local_after_cloud
 # @dottie/validate required_with=PF_ENABLE_CLOUD,boolean
 #MEDIA_DELETE_LOCAL_AFTER_CLOUD="true"
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#aws_access_key_id
 # @dottie/validate required_if=FILESYSTEM_CLOUD s3
 #AWS_ACCESS_KEY_ID=""
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#aws_secret_access_key
 # @dottie/validate required_if=FILESYSTEM_CLOUD s3
 #AWS_SECRET_ACCESS_KEY=""
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#aws_default_region
 # @dottie/validate required_if=FILESYSTEM_CLOUD s3
 #AWS_DEFAULT_REGION=""
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#aws_bucket
 # @dottie/validate required_if=FILESYSTEM_CLOUD s3
 #AWS_BUCKET=""
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#aws_url
 # @dottie/validate required_if=FILESYSTEM_CLOUD s3
 #AWS_URL=""
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#aws_endpoint
 # @dottie/validate required_if=FILESYSTEM_CLOUD s3
 #AWS_ENDPOINT=""
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#aws_use_path_style_endpoint
 # @dottie/validate required_if=FILESYSTEM_CLOUD s3
 #AWS_USE_PATH_STYLE_ENDPOINT="false"
 
@@ -766,41 +738,32 @@ REDIS_PORT="6379"
 
 # Comma-separated list of domains to block.
 #
-# @see https://docs.pixelfed.org/technical-documentation/config/#cs_blocked_domains
 #CS_BLOCKED_DOMAINS=""
 
 # Comma-separated list of domains to add warnings.
 #
-# @see https://docs.pixelfed.org/technical-documentation/config/#cs_cw_domains
 #CS_CW_DOMAINS=""
 
 # Comma-separated list of domains to remove from public timelines.
 #
-# @see https://docs.pixelfed.org/technical-documentation/config/#cs_unlisted_domains
 #CS_UNLISTED_DOMAINS=""
 
 # Comma-separated list of keywords to block.
 #
-# @see https://docs.pixelfed.org/technical-documentation/config/#cs_blocked_keywords
 #CS_BLOCKED_KEYWORDS=""
 
 # Comma-separated list of keywords to add warnings.
 #
-# @see https://docs.pixelfed.org/technical-documentation/config/#cs_cw_keywords
 #CS_CW_KEYWORDS=""
 
 # Comma-separated list of keywords to remove from public timelines.
 #
-# @see https://docs.pixelfed.org/technical-documentation/config/#cs_unlisted_keywords
 #CS_UNLISTED_KEYWORDS=""
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#cs_blocked_actor
 #CS_BLOCKED_ACTOR=""
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#cs_cw_actor
 #CS_CW_ACTOR=""
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#cs_unlisted_actor
 #CS_UNLISTED_ACTOR=""
 
 ################################################################################
@@ -827,20 +790,17 @@ LOG_CHANNEL="stderr"
 # Used by single, stderr and syslog.
 #
 # @default debug
-# @see https://docs.pixelfed.org/technical-documentation/config/#log_level
 # @dottie/validate oneof=debug info notice warning error critical alert emergency
 #LOG_LEVEL="debug"
 
 # Used by stderr.
 #
 # @default
-# @see https://docs.pixelfed.org/technical-documentation/config/#log_stderr_formatter
 #LOG_STDERR_FORMATTER=""
 
 # Used by slack.
 #
 # @default
-# @see https://docs.pixelfed.org/technical-documentation/config/#log_slack_webhook_url
 # @dottie/validate http_url
 #LOG_SLACK_WEBHOOK_URL=""
 
@@ -858,32 +818,26 @@ LOG_CHANNEL="stderr"
 # * null
 #
 # @default sync
-# @see https://docs.pixelfed.org/technical-documentation/config/#queue_driver
 # @dottie/validate required,oneof=sync database beanstalkd sqs redis null
 QUEUE_DRIVER="redis"
 
 # @default your-public-key
-# @see https://docs.pixelfed.org/technical-documentation/config/#sqs_key
 # @dottie/validate required_if=QUEUE_DRIVER sqs
 #SQS_KEY="your-public-key"
 
 # @default your-secret-key
-# @see https://docs.pixelfed.org/technical-documentation/config/#sqs_secret
 # @dottie/validate required_if=QUEUE_DRIVER sqs
 #SQS_SECRET="your-secret-key"
 
 # @default https://sqs.us-east-1.amazonaws.com/your-account-id
-# @see https://docs.pixelfed.org/technical-documentation/config/#sqs_prefix
 # @dottie/validate required_if=QUEUE_DRIVER sqs
 #SQS_PREFIX=""
 
 # @default your-queue-name
-# @see https://docs.pixelfed.org/technical-documentation/config/#sqs_queue
 # @dottie/validate required_if=QUEUE_DRIVER sqs
 #SQS_QUEUE="your-queue-name"
 
 # @default us-east-1
-# @see https://docs.pixelfed.org/technical-documentation/config/#sqs_region
 # @dottie/validate required_if=QUEUE_DRIVER sqs
 #SQS_REGION="us-east-1"
 
@@ -914,7 +868,6 @@ QUEUE_DRIVER="redis"
 # If you want them to immediately expire on the browser closing, set that option.
 #
 # @default 86400.
-# @see https://docs.pixelfed.org/technical-documentation/config/#session_lifetime
 # @dottie/validate number
 #SESSION_LIFETIME="86400"
 
@@ -925,7 +878,7 @@ QUEUE_DRIVER="redis"
 # A sensible default has been set.
 #
 # @default the value of APP_DOMAIN, or null.
-# @see https://docs.pixelfed.org/technical-documentation/config/#session_domain
+# @see https://docs.pixelfed.org/running-pixelfed/installation.html#app-variables
 # @dottie/validate required
 #SESSION_DOMAIN="${APP_DOMAIN}"
 
@@ -939,11 +892,9 @@ QUEUE_DRIVER="redis"
 # of Horizon on the same server so that they don’t have problems.
 #
 # @default horizon-
-# @see https://docs.pixelfed.org/technical-documentation/config/#horizon_prefix
 #HORIZON_PREFIX="horizon-"
 
 # @default false
-# @see https://docs.pixelfed.org/technical-documentation/config/#horizon_darkmode
 # @dottie/validate boolean
 #HORIZON_DARKMODE="false"
 
@@ -956,30 +907,23 @@ QUEUE_DRIVER="redis"
 # @dottie/validate number
 #HORIZON_MEMORY_LIMIT="64"
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#horizon_balance_strategy
 #HORIZON_BALANCE_STRATEGY="auto"
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#horizon_min_processes
 # @dottie/validate number
 #HORIZON_MIN_PROCESSES="1"
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#horizon_max_processes
 # @dottie/validate number
 #HORIZON_MAX_PROCESSES="20"
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#horizon_supervisor_memory
 # @dottie/validate number
 #HORIZON_SUPERVISOR_MEMORY="64"
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#horizon_supervisor_tries
 # @dottie/validate number
 #HORIZON_SUPERVISOR_TRIES="3"
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#horizon_supervisor_nice
 # @dottie/validate number
 #HORIZON_SUPERVISOR_NICE="0"
 
-# @see https://docs.pixelfed.org/technical-documentation/config/#horizon_supervisor_timeout
 # @dottie/validate number
 #HORIZON_SUPERVISOR_TIMEOUT="300"
 
@@ -994,7 +938,6 @@ QUEUE_DRIVER="redis"
 # This key is used by the Illuminate encrypter service and should be set to a random,
 # 32 character string, otherwise these encrypted strings will not be safe.
 #
-# @see https://docs.pixelfed.org/technical-documentation/config/#app_key
 # @dottie/validate required
 APP_KEY=
 


### PR DESCRIPTION
Remove broken documentation links. When possible, replace them with working links.
