### PR TITLE
feat: configure passport client keys when using 'login with mastodon'

### DIFF
--- a/docker/rootfs/shared/docker/entrypoint.d/11-first-time-setup.sh
+++ b/docker/rootfs/shared/docker/entrypoint.d/11-first-time-setup.sh
@@ -42,3 +42,7 @@ fi
 if is-true "${OAUTH_ENABLED:-false}"; then
     only-once "passport:keys" run-as-runtime-user php artisan passport:keys
 fi
+
+if is-true "${PF_LOGIN_WITH_MASTODON_ENABLED:-false}"; then
+    only-once "passport:client::personal" run-as-runtime-user php artisan passport:client --personal --name "Created_By_Docker_11-first-time-setup.sh"
+fi

--- a/docker/tests/e2e.sh
+++ b/docker/tests/e2e.sh
@@ -24,7 +24,7 @@ npx playwright install chromium --with-deps
 echo
 echo "==> Wait for the site to come up, while streaming the logs"
 echo
-curl --retry-delay 1 --retry 180 --retry-max-time 180 --retry-all-errors --fail -o /dev/null "http://${app_domain}:8080"
+curl --retry-delay 1 --retry 60 --retry-max-time 60 --retry-all-errors --fail -o /dev/null "http://${app_domain}:8080"
 
 echo
 echo "==> Run playwright tests"

--- a/docker/tests/setup.sh
+++ b/docker/tests/setup.sh
@@ -31,5 +31,7 @@ dottie set \
     DOCKER_PROXY_PROFILE="disabled" \
     ENFORCE_EMAIL_VERIFICATION="false" \
     INSTANCE_CONTACT_EMAIL="github@example.com" \
+    ACTIVITY_PUB="true" \
     OAUTH_ENABLED="true" \
+    PF_LOGIN_WITH_MASTODON_ENABLED="true" \
     DOCKER_APP_PHP_MEMORY_LIMIT="256M"


### PR DESCRIPTION
Without a personal token the `POST /auth/raw/mastodon/s/submit` would return `500 Internal Server Error` and the response `{"error":"Personal access client not found. Please create one."}`