### PR TITLE
fixed DOCKER_APP_RELEASE in set-recommended-versions to valid release

### DIFF
--- a/scripts/set-recommended-versions
+++ b/scripts/set-recommended-versions
@@ -15,7 +15,7 @@ DB_VERSION="11.6"
 DOCKER_APP_PHP_VERSION="8.4"
 
 # @renovate datasource=github-releases depName=jippi/docker-pixelfed versioning=semver-coerced
-DOCKER_APP_RELEASE="v0.14"
+DOCKER_APP_RELEASE="v0.12.5"
 
 # @renovate datasource=docker depName=nginxproxy/nginx-proxy versioning=semver-coerced
 DOCKER_PROXY_VERSION="1.7.1"

--- a/scripts/set-recommended-versions
+++ b/scripts/set-recommended-versions
@@ -15,7 +15,7 @@ DB_VERSION="11.6"
 DOCKER_APP_PHP_VERSION="8.4"
 
 # @renovate datasource=github-releases depName=jippi/docker-pixelfed versioning=semver-coerced
-DOCKER_APP_RELEASE="v0.12.5"
+DOCKER_APP_RELEASE="v0.12"
 
 # @renovate datasource=docker depName=nginxproxy/nginx-proxy versioning=semver-coerced
 DOCKER_PROXY_VERSION="1.7.1"


### PR DESCRIPTION
`scripts/set-recommended-versions` has `DOCKER_APP_RELEASE="v0.14"` which does not seem to exist. This appears to be a similar to the silly bug described in https://github.com/jippi/docker-pixelfed/issues/105. Looks like it's been there for a while.

Found it whilst looking for a more simplistic update path for non-breaking releases and found it was failing due to a non-existent release defined. Seems like 0.12.5 is appropriate.