### PR TITLE
fix: non-interactive passport:client --personal

### DIFF
--- a/docker/rootfs/shared/docker/entrypoint.d/11-first-time-setup.sh
+++ b/docker/rootfs/shared/docker/entrypoint.d/11-first-time-setup.sh
@@ -44,5 +44,7 @@ if is-true "${OAUTH_ENABLED:-false}"; then
 fi
 
 if is-true "${PF_LOGIN_WITH_MASTODON_ENABLED:-false}"; then
-    only-once "passport:client::personal" run-as-runtime-user php artisan passport:client --personal --name "Created_By_Docker_11-first-time-setup.sh"
+    # NOTE: [--provider] and [--no-interaction] are required, else newer versions of
+    # laravel/passport prompt for the user provider, which can't be answered in a container
+    only-once "passport:client::personal" run-as-runtime-user php artisan passport:client --personal --no-interaction --name "Created_By_Docker_11-first-time-setup.sh" --provider "${PF_PASSPORT_USER_PROVIDER:-users}"
 fi

--- a/docker/rootfs/shared/docker/entrypoint.sh
+++ b/docker/rootfs/shared/docker/entrypoint.sh
@@ -92,7 +92,9 @@ find "${ENTRYPOINT_D_ROOT}" -follow -type f -print | sort -V | while read -r fil
             log-info "${section_message_color}You can disable this script by setting [\$ENTRYPOINT_SKIP_SCRIPTS=\"${skip_value}\"] in your .env file"
             log-info "${section_message_color}============================================================${color_clear}"
 
-            "${file}"
+            # stdin is redirected from /dev/null so an (unexpectedly) interactive command
+            # can't consume the file list this loop is reading from
+            "${file}" </dev/null
             ;;
 
         *)


### PR DESCRIPTION
## Problem

All PR builds fail. `php artisan passport:client --personal` in `11-first-time-setup.sh` now prompts:

> Which user provider should this client use to retrieve users? [users]

laravel/passport v13 added the prompt (`ClientCommand::createPersonalAccessClient()`).

Worse: the entrypoint loop is `find … | while read -r file`, so the prompt inherited that pipe as stdin and consumed the remaining script paths as answers:

```
[ERROR] Value "/docker/entrypoint.d/12-migrations.sh" is invalid
[ERROR] Value "/docker/entrypoint.d/20-horizon.sh" is invalid
[ERROR] Value "/docker/entrypoint.d/30-cache.sh" is invalid
```

Those three scripts never ran, so the goss tests failed.

## Fix

- `11-first-time-setup.sh`: pass `--no-interaction --provider "${PF_PASSPORT_USER_PROVIDER:-users}"` (`users` matches pixelfed's `config/auth.php` `guards.api.provider`).
- `entrypoint.sh`: run entrypoint.d scripts with `</dev/null` so no future interactive command can eat the script list.