### PR TITLE
ci: rework Docker build caching and build arm64 natively

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -48,3 +48,15 @@ jobs:
         with:
           token: ${{ secrets.GH_CLEANUP_PAT }}
           delete-untagged: true
+
+      # The BuildKit cache lives in its own package so that reading it doesn't
+      # count towards the download numbers of the real image.
+      #
+      # Its tags are a fixed set that gets overwritten in place, but every
+      # rewrite orphans the manifest it replaced - so those need reaping.
+      - name: "Delete orphaned build cache"
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          token: ${{ secrets.GH_CLEANUP_PAT }}
+          packages: docker-pixelfed-buildcache
+          delete-untagged: true

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -6,10 +6,16 @@ on:
       - "*"
       - "**"
 
+env:
+  # Where the images are published
+  IMAGE: ghcr.io/${{ github.repository }}
+
 jobs:
-  pixelfed:
-    name: pixelfed
-    runs-on: ubuntu-24.04
+  # Build each architecture on a runner of that architecture, and push it
+  # untagged by digest. [merge] then assembles the tagged manifest list.
+  build:
+    name: build
+    runs-on: ${{ matrix.runner }}
 
     strategy:
       fail-fast: false
@@ -27,6 +33,9 @@ jobs:
         target_runtime:
           - apache
           - nginx
+        platform:
+          - amd64
+          - arm64
 
         # See: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#excluding-matrix-configurations
         # See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixexclude
@@ -39,6 +48,15 @@ jobs:
           - target_runtime: nginx
             php_base: apache
 
+        # Map each architecture onto a runner of that architecture.
+        #
+        # [ubuntu-24.04-arm] is free for public repositories.
+        include:
+          - platform: amd64
+            runner: ubuntu-24.04
+          - platform: arm64
+            runner: ubuntu-24.04-arm
+
     permissions:
       contents: read
       packages: write
@@ -48,7 +66,7 @@ jobs:
       # [docker-test.yml] on pushes to main.
       #
       # This job only ever *reads* it.
-      CACHE_REF: ghcr.io/${{ github.repository }}:buildcache-dev-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
+      CACHE_REF: ghcr.io/${{ github.repository }}-buildcache:dev-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}-${{ matrix.platform }}
 
     steps:
       # Checkout this repo
@@ -59,7 +77,7 @@ jobs:
         env:
           TAG_NAME: ${{ github.ref_name }}
         id: pixelfed_release
-        run: echo "fragment=${TAG_NAME%%-*}" >> $GITHUB_OUTPUT
+        run: echo "fragment=${TAG_NAME%%-*}" >> "$GITHUB_OUTPUT"
 
       # checkout pixelfed source code
       - name: Checkout pixelfed/pixelfed
@@ -68,9 +86,6 @@ jobs:
           repository: "pixelfed/pixelfed"
           ref: "${{ steps.pixelfed_release.outputs.fragment }}"
           path: "src/"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -84,12 +99,94 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: ${{ matrix.target_runtime }}-runtime
+          platforms: linux/${{ matrix.platform }}
+          builder: ${{ steps.buildx.outputs.name }}
+          provenance: false # https://github.com/docker/build-push-action/issues/894#issuecomment-1785937908
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            PHP_VERSION=${{ matrix.php_version }}
+            PHP_BASE_TYPE=${{ matrix.php_base }}
+            PHP_DEBIAN_RELEASE=${{ matrix.debian_release }}
+          cache-from: |
+            type=registry,ref=${{ env.CACHE_REF }}
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ matrix.target_runtime }}-${{ matrix.php_version }}-${{ matrix.debian_release }}-${{ matrix.platform }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the per-architecture digests into the tagged manifest list that
+  # users actually pull.
+  merge:
+    name: merge
+    runs-on: ubuntu-24.04
+    needs:
+      - build
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        php_version:
+          - 8.3
+          - 8.4
+        debian_release:
+          - bookworm
+        target_runtime:
+          - apache
+          - nginx
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Find Pixelfed release tag
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        id: pixelfed_release
+        run: echo "fragment=${TAG_NAME%%-*}" >> "$GITHUB_OUTPUT"
+
+      - name: Download digests
+        uses: actions/download-artifact@v6
+        with:
+          pattern: digests-${{ matrix.target_runtime }}-${{ matrix.php_version }}-${{ matrix.debian_release }}-*
+          merge-multiple: true
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Docker meta
         uses: docker/metadata-action@v6
         id: meta
         with:
           images: |
-            name=ghcr.io/${{ github.repository }}
+            name=${{ env.IMAGE }}
           flavor: |
             suffix=-${{ matrix.target_runtime }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
             prefix=v
@@ -106,21 +203,21 @@ jobs:
             type=semver,pattern={{ major }}.{{ minor }}.{{ patch }},value=${{ steps.pixelfed_release.outputs.fragment }}
             type=semver,pattern={{ version }},value=${{ steps.pixelfed_release.outputs.fragment }}
 
-      - name: Build and push image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/Dockerfile
-          target: ${{ matrix.target_runtime }}-runtime
-          platforms: linux/amd64,linux/arm64
-          builder: ${{ steps.buildx.outputs.name }}
-          tags: ${{ steps.meta.outputs.tags }}
-          annotations: ${{ steps.meta.outputs.annotations }}
-          push: true
-          provenance: false # https://github.com/docker/build-push-action/issues/894#issuecomment-1785937908
-          build-args: |
-            PHP_VERSION=${{ matrix.php_version }}
-            PHP_BASE_TYPE=${{ matrix.php_base }}
-            PHP_DEBIAN_RELEASE=${{ matrix.debian_release }}
-          cache-from: |
-            type=registry,ref=${{ env.CACHE_REF }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          sources=()
+          for digest in *; do
+              sources+=("${IMAGE}@sha256:${digest}")
+          done
+
+          # shellcheck disable=SC2046 # deliberate word splitting of the --tag list
+          docker buildx imagetools create \
+            $(jq --raw-output --compact-output '.tags | map("--tag " + .) | join(" ")' <<< "${DOCKER_METADATA_OUTPUT_JSON}") \
+            "${sources[@]}"
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect "${IMAGE}:${VERSION}"
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -43,19 +43,17 @@ jobs:
       contents: read
       packages: write
 
+    env:
+      # Registry-backed build cache, written by the 'dev' matrix entries of
+      # [docker-test.yml] on pushes to main.
+      #
+      # This job only ever *reads* it.
+      CACHE_REF: ghcr.io/${{ github.repository }}:buildcache-dev-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
+
     steps:
       # Checkout this repo
       - name: Checkout Code
         uses: actions/checkout@v6
-
-      - name: Restore buildx cache
-        uses: actions/cache/restore@v5
-        with:
-          key: buildx-cache-dev-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}-${{ hashFiles('docker/**') }}
-          restore-keys: |
-            buildx-cache-dev-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}-
-          path: |
-            .cache/buildx
 
       - name: Find Pixelfed release tag
         env:
@@ -125,4 +123,4 @@ jobs:
             PHP_BASE_TYPE=${{ matrix.php_base }}
             PHP_DEBIAN_RELEASE=${{ matrix.debian_release }}
           cache-from: |
-            type=local,src=.cache/buildx
+            type=registry,ref=${{ env.CACHE_REF }}

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -533,23 +533,34 @@ jobs:
     steps:
       - name: Check job results
         env:
-          # 'success', 'failure', 'cancelled' or 'skipped' per needed job.
+          # Keyed by job name, so a failure can say *which* job failed rather
+          # than just that something did.
           #
-          # For a matrix job this is the aggregate: 'failure' if any leg failed.
-          RESULTS: ${{ join(needs.*.result, ' ') }}
+          # For a matrix job the result is the aggregate: 'failure' if any leg
+          # failed.
+          #
+          # ! NOTE: the observed values are wider than the documented
+          # !       success/failure/cancelled/skipped - a GitHub Actions
+          # !       incident produced 'abandoned' here. Treat anything that is
+          # !       not an explicit pass as a failure, rather than listing the
+          # !       ways a job can go wrong.
+          NEEDS: ${{ toJSON(needs) }}
         run: |
-          echo "dependency results: ${RESULTS}"
+          jq --raw-output 'to_entries[] | "  \(.value.result)\t\(.key)"' <<< "${NEEDS}"
 
-          # 'skipped' is a pass: [build] publishes nothing and [merge] does not
-          # run at all for Renovate and fork pull requests, by design.
-          for result in ${RESULTS}; do
-              case "${result}" in
-                  success | skipped) ;;
-                  *)
-                      echo "::error::a job this check depends on concluded '${result}'"
-                      exit 1
-                      ;;
-              esac
-          done
+          # 'skipped' is a pass: [merge] does not run for Renovate and fork
+          # pull requests, by design.
+          failed=$(jq --raw-output '
+              to_entries[]
+              | select(.value.result != "success" and .value.result != "skipped")
+              | "\(.key) (\(.value.result))"
+          ' <<< "${NEEDS}")
+
+          if [ -n "${failed}" ]; then
+              while read -r job; do
+                  echo "::error::${job} did not pass"
+              done <<< "${failed}"
+              exit 1
+          fi
 
           echo "all good"

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -19,9 +19,6 @@ on:
     branches:
       - main
 
-  # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
-  # pull_request:
-
   # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
   schedule:
     #        ┌───────────── minute (0 - 59)
@@ -33,6 +30,25 @@ on:
     #        │  │ │ │ │
     #        │  │ │ │ │
     - cron: "30 8 * * *" # run at 8:30 AM UTC
+
+# Supersede in-flight runs for the same branch, except on [main] where the run
+# also refreshes the shared build cache.
+concurrency:
+  group: docker-test-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  # Where the images are published
+  IMAGE: ghcr.io/${{ github.repository }}
+
+  # Where the BuildKit cache lives.
+  #
+  # ! This is deliberately a *separate* package from [IMAGE]:
+  # !
+  # !   1. Cache reads would otherwise be counted as pulls of the real image,
+  # !      inflating the download numbers we use to gauge actual usage.
+  # !   2. It keeps the cleanup rules for the two from interfering.
+  CACHE_IMAGE: ghcr.io/${{ github.repository }}-buildcache
 
 jobs:
   bats:
@@ -61,9 +77,15 @@ jobs:
           config: docker/.hadolint.yaml
           failure-threshold: error
 
-  pixelfed:
-    name: pixelfed
+  # Build the image for the runner's own architecture and test it, without
+  # involving the registry at all.
+  #
+  # Publishing is handled separately by [publish] + [merge] below, so test
+  # feedback doesn't wait on the arm64 build or on a registry round-trip.
+  test:
+    name: test
     runs-on: ubuntu-24.04
+
     strategy:
       fail-fast: false
 
@@ -85,7 +107,6 @@ jobs:
           - nginx
 
         # See: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#excluding-matrix-configurations
-        # See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixexclude
         exclude:
           # targeting [apache] runtime with [fpm] base type doesn't make sense
           - target_runtime: apache
@@ -95,34 +116,12 @@ jobs:
           - target_runtime: nginx
             php_base: apache
 
-    # See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-concurrency-and-the-default-behavior
-    concurrency:
-      group: pixelfed-${{ github.ref }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.target_runtime }}-${{ matrix.pixelfed_branch }}-
-      cancel-in-progress: true
-
     permissions:
       contents: read
-      packages: write
+      packages: read
 
     env:
-      # Registry-backed build cache, shared with [docker-release.yml].
-      #
-      # We use a registry cache rather than [actions/cache] because the GitHub
-      # Actions cache is capped at 10 GB per repository, and ~900 MB per matrix
-      # entry meant the caches were evicted before they could be reused.
-      CACHE_REF: ghcr.io/${{ github.repository }}:buildcache-${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
-
-      # Build a single (native) architecture and keep the image on the runner
-      # instead of building multi-arch under QEMU and pushing it to ghcr.io.
-      #
-      # We only do this when nobody is realistically going to pull the image:
-      #
-      #   * Renovate pull requests (bot-authored dependency bumps)
-      #   * Fork pull requests (which can't push to ghcr.io anyway)
-      #
-      # Human pull requests still publish multi-arch images, so the changes can
-      # be tested on arm64 hardware by end-users.
-      LOCAL_ONLY: ${{ github.event_name == 'pull_request' && (startsWith(github.head_ref, 'renovate/') || github.event.pull_request.head.repo.full_name != github.repository) }}
+      CACHE_REF: ghcr.io/${{ github.repository }}-buildcache:${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}-amd64
 
     steps:
       # Checkout this repo
@@ -147,11 +146,6 @@ jobs:
             "https://github.com/jippi/dottie/releases/download/v${DOTTIE_VERSION}/dottie_${DOTTIE_VERSION}_amd64.deb"
           sudo dpkg --install /tmp/dottie.deb
 
-      # Only needed when we cross-build for arm64
-      - name: Set up QEMU
-        if: env.LOCAL_ONLY != 'true'
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         id: buildx
@@ -169,7 +163,7 @@ jobs:
         id: meta
         with:
           images: |
-            name=ghcr.io/${{ github.repository }},enable=true
+            name=${{ env.IMAGE }},enable=true
           flavor: |
             suffix=-${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
           tags: |
@@ -180,35 +174,27 @@ jobs:
             type=ref,event=branch,prefix=branch/
             type=ref,event=pr,prefix=pr/
 
-      - name: Build and push image
+      # Single architecture, kept on the runner. The [publish] job is what
+      # actually pushes anything.
+      - name: Build image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile
           target: ${{ matrix.target_runtime }}-runtime
-          platforms: ${{ env.LOCAL_ONLY == 'true' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: linux/amd64
           builder: ${{ steps.buildx.outputs.name }}
           tags: ${{ steps.meta.outputs.tags }}
           annotations: ${{ steps.meta.outputs.annotations }}
-          push: ${{ env.LOCAL_ONLY != 'true' }}
-          load: ${{ env.LOCAL_ONLY == 'true' }}
+          load: true
           provenance: false # https://github.com/docker/build-push-action/issues/894#issuecomment-1785937908
           build-args: |
             PHP_VERSION=${{ matrix.php_version }}
             PHP_BASE_TYPE=${{ matrix.php_base }}
             PHP_DEBIAN_RELEASE=${{ matrix.debian_release }}
+          # Read-only. The cache is written by [publish] on [main] only.
           cache-from: |
             type=registry,ref=${{ env.CACHE_REF }}
-          # ! SECURITY: only ever write the cache from the [main] branch.
-          # !
-          # ! Unlike [actions/cache], a registry cache is *not* scoped per branch,
-          # ! so anything able to write here could inject layers into the images
-          # ! produced by [docker-release.yml].
-          # !
-          # ! Gating on the ref (rather than the event) means pull requests and
-          # ! [workflow_dispatch] runs on a side branch can read the cache, but
-          # ! never write it. The nightly [schedule] run keeps it warm.
-          cache-to: ${{ github.ref == 'refs/heads/main' && format('type=registry,mode=max,ref={0}', env.CACHE_REF) || '' }}
 
       - name: Setup
         run: docker/tests/setup.sh
@@ -282,3 +268,218 @@ jobs:
           name: playwright-report-${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
           path: test-results/
           retention-days: 30
+
+  # Build each architecture on a runner of that architecture - arm64 under QEMU
+  # used to account for ~73% of the total build time.
+  #
+  # Each job pushes an untagged, single-architecture image by digest; [merge]
+  # then assembles those digests into the tagged manifest list.
+  publish:
+    name: publish
+    runs-on: ${{ matrix.runner }}
+
+    # Skip publishing entirely when nobody is going to pull the result:
+    #
+    #   * Renovate pull requests (bot-authored dependency bumps)
+    #   * Fork pull requests (whose GITHUB_TOKEN is read-only, so they cannot
+    #     push to ghcr.io regardless of the permissions requested below)
+    #
+    # Human pull requests still publish multi-arch images, so the changes can
+    # be tested on arm64 hardware by end-users.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (!startsWith(github.head_ref, 'renovate/') &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        php_version:
+          - 8.3
+          - 8.4
+        pixelfed_branch:
+          - staging
+          - dev
+        debian_release:
+          - bookworm
+        php_base:
+          - apache
+          - fpm
+        target_runtime:
+          - apache
+          - nginx
+        platform:
+          - amd64
+          - arm64
+
+        exclude:
+          # targeting [apache] runtime with [fpm] base type doesn't make sense
+          - target_runtime: apache
+            php_base: fpm
+
+          # targeting [nginx] runtime with [apache] base type doesn't make sense
+          - target_runtime: nginx
+            php_base: apache
+
+        # Map each architecture onto a runner of that architecture.
+        #
+        # [ubuntu-24.04-arm] is free for public repositories.
+        include:
+          - platform: amd64
+            runner: ubuntu-24.04
+          - platform: arm64
+            runner: ubuntu-24.04-arm
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      CACHE_REF: ghcr.io/${{ github.repository }}-buildcache:${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}-${{ matrix.platform }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Checkout pixelfed/pixelfed
+        uses: actions/checkout@v6
+        with:
+          repository: "pixelfed/pixelfed"
+          ref: "${{ matrix.pixelfed_branch }}"
+          path: "src/"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        id: buildx
+
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: ${{ matrix.target_runtime }}-runtime
+          platforms: linux/${{ matrix.platform }}
+          builder: ${{ steps.buildx.outputs.name }}
+          provenance: false # https://github.com/docker/build-push-action/issues/894#issuecomment-1785937908
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            PHP_VERSION=${{ matrix.php_version }}
+            PHP_BASE_TYPE=${{ matrix.php_base }}
+            PHP_DEBIAN_RELEASE=${{ matrix.debian_release }}
+          cache-from: |
+            type=registry,ref=${{ env.CACHE_REF }}
+          # ! SECURITY: only ever write the cache from the [main] branch.
+          # !
+          # ! Unlike [actions/cache], a registry cache is *not* scoped per branch,
+          # ! so anything able to write here could inject layers into the images
+          # ! produced by [docker-release.yml].
+          # !
+          # ! Gating on the ref (rather than the event) means pull requests and
+          # ! [workflow_dispatch] runs on a side branch can read the cache, but
+          # ! never write it. The nightly [schedule] run keeps it warm.
+          cache-to: ${{ github.ref == 'refs/heads/main' && format('type=registry,mode=max,ref={0}', env.CACHE_REF) || '' }}
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_version }}-${{ matrix.debian_release }}-${{ matrix.platform }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the per-architecture digests into the tagged manifest list that
+  # users actually pull.
+  merge:
+    name: merge
+    runs-on: ubuntu-24.04
+    needs:
+      - publish
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        php_version:
+          - 8.3
+          - 8.4
+        pixelfed_branch:
+          - staging
+          - dev
+        debian_release:
+          - bookworm
+        target_runtime:
+          - apache
+          - nginx
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v6
+        with:
+          pattern: digests-${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_version }}-${{ matrix.debian_release }}-*
+          merge-multiple: true
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: |
+            name=${{ env.IMAGE }},enable=true
+          flavor: |
+            suffix=-${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
+          tags: |
+            # schedule
+            type=schedule,pattern=nightly
+            type=schedule,pattern=nightly-{{ date 'YYYY-MM-DD' tz='UTC' }}
+            # default behavior
+            type=ref,event=branch,prefix=branch/
+            type=ref,event=pr,prefix=pr/
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          sources=()
+          for digest in *; do
+              sources+=("${IMAGE}@sha256:${digest}")
+          done
+
+          # shellcheck disable=SC2046 # deliberate word splitting of the --tag list
+          docker buildx imagetools create \
+            $(jq --raw-output --compact-output '.tags | map("--tag " + .) | join(" ")' <<< "${DOCKER_METADATA_OUTPUT_JSON}") \
+            "${sources[@]}"
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect "${IMAGE}:${VERSION}"
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -272,24 +272,15 @@ jobs:
   # Build each architecture on a runner of that architecture - arm64 under QEMU
   # used to account for ~73% of the total build time.
   #
-  # Each job pushes an untagged, single-architecture image by digest; [merge]
-  # then assembles those digests into the tagged manifest list.
-  publish:
-    name: publish
+  # This *always* runs, on every event, so that a change which only breaks one
+  # architecture cannot slip through. That matters most for Renovate pull
+  # requests, which auto-merge: an arm64-only breakage there would otherwise
+  # not surface until the next release build.
+  #
+  # Whether the result is pushed is a separate question - see [NO_PUBLISH].
+  build:
+    name: build
     runs-on: ${{ matrix.runner }}
-
-    # Skip publishing entirely when nobody is going to pull the result:
-    #
-    #   * Renovate pull requests (bot-authored dependency bumps)
-    #   * Fork pull requests (whose GITHUB_TOKEN is read-only, so they cannot
-    #     push to ghcr.io regardless of the permissions requested below)
-    #
-    # Human pull requests still publish multi-arch images, so the changes can
-    # be tested on arm64 hardware by end-users.
-    if: >-
-      github.event_name != 'pull_request' ||
-      (!startsWith(github.head_ref, 'renovate/') &&
-       github.event.pull_request.head.repo.full_name == github.repository)
 
     strategy:
       fail-fast: false
@@ -338,6 +329,19 @@ jobs:
     env:
       CACHE_REF: ghcr.io/${{ github.repository }}-buildcache:${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}-${{ matrix.platform }}
 
+      # Build, but don't push, when nobody is going to pull the result:
+      #
+      #   * Renovate pull requests (bot-authored dependency bumps)
+      #   * Fork pull requests (whose GITHUB_TOKEN is read-only, so they
+      #     cannot push to ghcr.io regardless of the permissions requested)
+      #
+      # Human pull requests still publish multi-arch images, so the changes
+      # can be tested on arm64 hardware by end-users.
+      #
+      # ! NOTE: this only controls *publishing*. Both architectures are built
+      # !       either way, so breakage is always caught.
+      NO_PUBLISH: ${{ github.event_name == 'pull_request' && (startsWith(github.head_ref, 'renovate/') || github.event.pull_request.head.repo.full_name != github.repository) }}
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -360,7 +364,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push by digest
+      - name: Build (and push by digest, unless NO_PUBLISH)
         id: build
         uses: docker/build-push-action@v7
         with:
@@ -370,7 +374,9 @@ jobs:
           platforms: linux/${{ matrix.platform }}
           builder: ${{ steps.buildx.outputs.name }}
           provenance: false # https://github.com/docker/build-push-action/issues/894#issuecomment-1785937908
-          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          # [cacheonly] still runs the whole build - it just throws the result
+          # away instead of exporting it anywhere.
+          outputs: ${{ env.NO_PUBLISH == 'true' && 'type=cacheonly' || format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.IMAGE) }}
           build-args: |
             PHP_VERSION=${{ matrix.php_version }}
             PHP_BASE_TYPE=${{ matrix.php_base }}
@@ -389,6 +395,7 @@ jobs:
           cache-to: ${{ github.ref == 'refs/heads/main' && format('type=registry,mode=max,ref={0}', env.CACHE_REF) || '' }}
 
       - name: Export digest
+        if: env.NO_PUBLISH != 'true'
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
@@ -396,6 +403,7 @@ jobs:
           touch "/tmp/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
+        if: env.NO_PUBLISH != 'true'
         uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_version }}-${{ matrix.debian_release }}-${{ matrix.platform }}
@@ -406,7 +414,7 @@ jobs:
   # Assemble the per-architecture digests into the tagged manifest list that
   # users actually pull.
   #
-  # [publish] and [test] run concurrently - the per-architecture images are
+  # [build] and [test] run concurrently - the per-architecture images are
   # pushed *untagged*, by digest, so they are inert until this job names them.
   #
   # Depending on [test] here is what makes the tag conditional on the tests
@@ -416,8 +424,16 @@ jobs:
     name: merge
     runs-on: ubuntu-24.04
     needs:
-      - publish
+      - build
       - test
+
+    # Nothing was pushed, so there are no digests to assemble.
+    #
+    # ! Must mirror [NO_PUBLISH] in the [build] job.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (!startsWith(github.head_ref, 'renovate/') &&
+       github.event.pull_request.head.repo.full_name == github.repository)
 
     strategy:
       fail-fast: false
@@ -491,3 +507,49 @@ jobs:
           docker buildx imagetools inspect "${IMAGE}:${VERSION}"
         env:
           VERSION: ${{ steps.meta.outputs.version }}
+
+  # Single aggregate status check for this whole workflow.
+  #
+  # Renovate auto-merges, so anything that can break has to be *required* -
+  # but requiring the matrix jobs by name means the branch ruleset silently
+  # stops covering them the moment a matrix axis or a job name changes, and a
+  # required check that never reports blocks every pull request instead.
+  #
+  # Requiring this one job avoids both failure modes: it always reports, and
+  # it fails if anything it depends on did.
+  #
+  # ! When adding a job to this workflow, add it to [needs] as well.
+  ci-ok:
+    name: ci-ok
+    runs-on: ubuntu-24.04
+    if: always()
+    needs:
+      - bats
+      - hadolint
+      - test
+      - build
+      - merge
+
+    steps:
+      - name: Check job results
+        env:
+          # 'success', 'failure', 'cancelled' or 'skipped' per needed job.
+          #
+          # For a matrix job this is the aggregate: 'failure' if any leg failed.
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "dependency results: ${RESULTS}"
+
+          # 'skipped' is a pass: [build] publishes nothing and [merge] does not
+          # run at all for Renovate and fork pull requests, by design.
+          for result in ${RESULTS}; do
+              case "${result}" in
+                  success | skipped) ;;
+                  *)
+                      echo "::error::a job this check depends on concluded '${result}'"
+                      exit 1
+                      ;;
+              esac
+          done
+
+          echo "all good"

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -104,22 +104,30 @@ jobs:
       contents: read
       packages: write
 
+    env:
+      # Registry-backed build cache, shared with [docker-release.yml].
+      #
+      # We use a registry cache rather than [actions/cache] because the GitHub
+      # Actions cache is capped at 10 GB per repository, and ~900 MB per matrix
+      # entry meant the caches were evicted before they could be reused.
+      CACHE_REF: ghcr.io/${{ github.repository }}:buildcache-${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}
+
+      # Build a single (native) architecture and keep the image on the runner
+      # instead of building multi-arch under QEMU and pushing it to ghcr.io.
+      #
+      # We only do this when nobody is realistically going to pull the image:
+      #
+      #   * Renovate pull requests (bot-authored dependency bumps)
+      #   * Fork pull requests (which can't push to ghcr.io anyway)
+      #
+      # Human pull requests still publish multi-arch images, so the changes can
+      # be tested on arm64 hardware by end-users.
+      LOCAL_ONLY: ${{ github.event_name == 'pull_request' && (startsWith(github.head_ref, 'renovate/') || github.event.pull_request.head.repo.full_name != github.repository) }}
+
     steps:
       # Checkout this repo
       - name: Checkout Code
         uses: actions/checkout@v6
-
-      - name: Restore buildx cache (from 'dev' build)
-        uses: actions/cache/restore@v5
-        with:
-          key: buildx-cache-${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}-${{ hashFiles('docker/**') }}
-          restore-keys: |
-            buildx-cache-${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}-
-          path: |
-            .cache/buildx
-
-      - name: Ensure buildx cache directory exists
-        run: mkdir -pv .cache/buildx
 
       # Checkout pixelfed source code into src/
       - name: Checkout pixelfed/pixelfed
@@ -130,12 +138,18 @@ jobs:
           path: "src/"
 
       - name: install dottie
+        env:
+          # renovate: datasource=github-releases depName=jippi/dottie
+          DOTTIE_VERSION: "1.2.0"
         run: |
-          echo 'deb [trusted=yes] https://pkg.jippi.dev/apt/ * *' | sudo tee /etc/apt/sources.list.d/dottie.list
-          sudo apt update
-          sudo apt install dottie
+          curl --fail --silent --show-error --location \
+            --output /tmp/dottie.deb \
+            "https://github.com/jippi/dottie/releases/download/v${DOTTIE_VERSION}/dottie_${DOTTIE_VERSION}_amd64.deb"
+          sudo dpkg --install /tmp/dottie.deb
 
+      # Only needed when we cross-build for arm64
       - name: Set up QEMU
+        if: env.LOCAL_ONLY != 'true'
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
@@ -172,28 +186,29 @@ jobs:
           context: .
           file: docker/Dockerfile
           target: ${{ matrix.target_runtime }}-runtime
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.LOCAL_ONLY == 'true' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           builder: ${{ steps.buildx.outputs.name }}
           tags: ${{ steps.meta.outputs.tags }}
           annotations: ${{ steps.meta.outputs.annotations }}
-          push: true
+          push: ${{ env.LOCAL_ONLY != 'true' }}
+          load: ${{ env.LOCAL_ONLY == 'true' }}
           provenance: false # https://github.com/docker/build-push-action/issues/894#issuecomment-1785937908
           build-args: |
             PHP_VERSION=${{ matrix.php_version }}
             PHP_BASE_TYPE=${{ matrix.php_base }}
             PHP_DEBIAN_RELEASE=${{ matrix.debian_release }}
           cache-from: |
-            type=local,src=.cache/buildx
-          cache-to: |
-            type=local,dest=.cache/buildx,mode=min
-
-      - name: Save buildx cache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v5
-        with:
-          key: buildx-cache-${{ matrix.pixelfed_branch }}-${{ matrix.target_runtime }}-${{ matrix.php_base }}-${{ matrix.php_version }}-${{ matrix.debian_release }}-${{ hashFiles('docker/**') }}
-          path: |
-            .cache/buildx
+            type=registry,ref=${{ env.CACHE_REF }}
+          # ! SECURITY: only ever write the cache from the [main] branch.
+          # !
+          # ! Unlike [actions/cache], a registry cache is *not* scoped per branch,
+          # ! so anything able to write here could inject layers into the images
+          # ! produced by [docker-release.yml].
+          # !
+          # ! Gating on the ref (rather than the event) means pull requests and
+          # ! [workflow_dispatch] runs on a side branch can read the cache, but
+          # ! never write it. The nightly [schedule] run keeps it warm.
+          cache-to: ${{ github.ref == 'refs/heads/main' && format('type=registry,mode=max,ref={0}', env.CACHE_REF) || '' }}
 
       - name: Setup
         run: docker/tests/setup.sh

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -405,11 +405,19 @@ jobs:
 
   # Assemble the per-architecture digests into the tagged manifest list that
   # users actually pull.
+  #
+  # [publish] and [test] run concurrently - the per-architecture images are
+  # pushed *untagged*, by digest, so they are inert until this job names them.
+  #
+  # Depending on [test] here is what makes the tag conditional on the tests
+  # passing, without serialising the two: an untagged digest from a failed run
+  # is just garbage, and gets reaped by the weekly [delete-untagged] cleanup.
   merge:
     name: merge
     runs-on: ubuntu-24.04
     needs:
       - publish
+      - test
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -20,10 +20,14 @@ jobs:
           fetch-depth: 0
 
       - name: install dottie
+        env:
+          # renovate: datasource=github-releases depName=jippi/dottie
+          DOTTIE_VERSION: "1.2.0"
         run: |
-          echo 'deb [trusted=yes] https://pkg.jippi.dev/apt/ * *' | sudo tee /etc/apt/sources.list.d/dottie.list
-          sudo apt update
-          sudo apt install dottie
+          curl --fail --silent --show-error --location \
+            --output /tmp/dottie.deb \
+            "https://github.com/jippi/dottie/releases/download/v${DOTTIE_VERSION}/dottie_${DOTTIE_VERSION}_amd64.deb"
+          sudo dpkg --install /tmp/dottie.deb
 
       - name: generate .env docs
         run: dottie template --file .env.docker --with-disabled docs-customization/template/dot-env.template.tmpl > docs/customize/settings.md

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -32,8 +32,19 @@ jobs:
       - name: generate .env docs
         run: dottie template --file .env.docker --with-disabled docs-customization/template/dot-env.template.tmpl > docs/customize/settings.md
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: build
-        run: docker build -t docker-pixelfed-docs -f Dockerfile.docs .
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.docs
+          tags: docker-pixelfed-docs
+          load: true
+          # Shared with [docs.yml], which builds the same image on every
+          # docs-touching push and keeps this warm.
+          cache-from: type=gha,scope=docs
 
       - name: change git source
         run: git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,19 +10,6 @@ on:
       - "*"
       - "**"
 
-    # Building the docs site and crawling it for dead links takes a couple of
-    # minutes, so only do it when something that ends up *in* the site changes.
-    #
-    # Use [workflow_dispatch] above to run it on demand for any other reason.
-    paths:
-      - "docs/**"
-      - "docs-customization/**"
-      - "mkdocs.yml"
-      - "Dockerfile.docs"
-      - ".env.docker"
-      - ".markdownlint.yml"
-      - ".github/workflows/docs.yml"
-
 # Only keep the newest run per branch alive
 concurrency:
   group: docs-${{ github.ref }}
@@ -32,12 +19,42 @@ jobs:
   deadlinks:
     name: "dead links"
     runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
+      # Building the docs site and crawling it for dead links takes a couple of
+      # minutes, so only do it when something that ends up *in* the site changed.
+      #
+      # ! NOTE: this is deliberately *not* a [paths:] filter on the workflow.
+      # !
+      # ! [dead links] is a required status check, and a workflow that never
+      # ! runs never reports one - which leaves every pull request that doesn't
+      # ! touch the docs waiting on a check that can't arrive.
+      # !
+      # ! Skipping the steps instead keeps the job (and therefore the check)
+      # ! reporting on every push.
+      - name: check for docs changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'docs-customization/**'
+              - 'mkdocs.yml'
+              - 'Dockerfile.docs'
+              - '.env.docker'
+              - '.markdownlint.yml'
+              - '.github/workflows/docs.yml'
+
       - name: install dottie
+        if: steps.changes.outputs.docs == 'true'
         env:
           # renovate: datasource=github-releases depName=jippi/dottie
           DOTTIE_VERSION: "1.2.0"
@@ -48,12 +65,15 @@ jobs:
           sudo dpkg --install /tmp/dottie.deb
 
       - name: generate .env docs
+        if: steps.changes.outputs.docs == 'true'
         run: dottie template --file .env.docker --with-disabled docs-customization/template/dot-env.template.tmpl > docs/customize/settings.md
 
       - name: Set up Docker Buildx
+        if: steps.changes.outputs.docs == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: build container
+        if: steps.changes.outputs.docs == 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -64,20 +84,25 @@ jobs:
           cache-to: type=gha,scope=docs,mode=max
 
       - name: dist site
+        if: steps.changes.outputs.docs == 'true'
         run: docker run --rm -v ${PWD}:/docs docker-pixelfed-docs build
 
       - name: "Setup NodeJS"
+        if: steps.changes.outputs.docs == 'true'
         uses: actions/setup-node@v6
 
       - name: Start HTTP server
+        if: steps.changes.outputs.docs == 'true'
         run: |
           find site/
           npx http-server --port 8000 site/ &
 
       - name: Wait for HTTP server to respond
+        if: steps.changes.outputs.docs == 'true'
         run: curl --retry-delay 1 --retry 30 --retry-max-time 30 --retry-all-errors --fail -o /dev/null http://0.0.0.0:8000/
 
       - name: check for dead links
+        if: steps.changes.outputs.docs == 'true'
         run : |
           docker run --rm --net=host raviqqe/muffet \
             --verbose \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,24 @@ on:
       - "*"
       - "**"
 
+    # Building the docs site and crawling it for dead links takes a couple of
+    # minutes, so only do it when something that ends up *in* the site changes.
+    #
+    # Use [workflow_dispatch] above to run it on demand for any other reason.
+    paths:
+      - "docs/**"
+      - "docs-customization/**"
+      - "mkdocs.yml"
+      - "Dockerfile.docs"
+      - ".env.docker"
+      - ".markdownlint.yml"
+      - ".github/workflows/docs.yml"
+
+# Only keep the newest run per branch alive
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deadlinks:
     name: "dead links"
@@ -20,10 +38,14 @@ jobs:
           fetch-depth: 0
 
       - name: install dottie
+        env:
+          # renovate: datasource=github-releases depName=jippi/dottie
+          DOTTIE_VERSION: "1.2.0"
         run: |
-          echo 'deb [trusted=yes] https://pkg.jippi.dev/apt/ * *' | sudo tee /etc/apt/sources.list.d/dottie.list
-          sudo apt update
-          sudo apt install dottie
+          curl --fail --silent --show-error --location \
+            --output /tmp/dottie.deb \
+            "https://github.com/jippi/dottie/releases/download/v${DOTTIE_VERSION}/dottie_${DOTTIE_VERSION}_amd64.deb"
+          sudo dpkg --install /tmp/dottie.deb
 
       - name: generate .env docs
         run: dottie template --file .env.docker --with-disabled docs-customization/template/dot-env.template.tmpl > docs/customize/settings.md

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,8 +50,18 @@ jobs:
       - name: generate .env docs
         run: dottie template --file .env.docker --with-disabled docs-customization/template/dot-env.template.tmpl > docs/customize/settings.md
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: build container
-        run: docker build -t docker-pixelfed-docs -f Dockerfile.docs .
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.docs
+          tags: docker-pixelfed-docs
+          load: true
+          cache-from: type=gha,scope=docs
+          cache-to: type=gha,scope=docs,mode=max
 
       - name: dist site
         run: docker run --rm -v ${PWD}:/docs docker-pixelfed-docs build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,11 @@ on:
       - "*"
       - "**"
 
+# Only keep the newest run per branch alive
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   shellcheck:
     name: ShellCheck

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,6 +47,12 @@ ARG PHP_BASE_TYPE="apache"
 ARG PHP_DEBIAN_RELEASE="bookworm"
 ARG APT_PACKAGES_EXTRA=
 
+# Whether to build the frontend assets with npm.
+#
+# ! NOTE: must be a *global* ARG (declared before the first FROM) since it
+# !       selects which [frontend-build-*] stage is aliased to [frontend-build]
+ARG BUILD_FRONTEND="0"
+
 # PHP extensions installed via [pecl install]
 ARG PHP_PECL_EXTENSIONS=""
 ARG PHP_PECL_EXTENSIONS_EXTRA=
@@ -200,9 +206,9 @@ USER ${RUNTIME_UID}:${RUNTIME_GID}
 # We force the (CPU) [--platform] here to be architecture
 # of the "builder"/"server" and not the *target* CPU architecture
 # (e.g.) building the ARM version of Pixelfed on AMD64.
-FROM --platform=${BUILDARCH} node:lts AS frontend-build
+FROM --platform=${BUILDARCH} node:lts AS frontend-build-1
 
-ARG BUILD_FRONTEND=0
+ARG BUILD_FRONTEND
 ARG BUILDARCH
 ARG RUNTIME_GID
 ARG RUNTIME_UID
@@ -263,6 +269,25 @@ RUN --mount=type=cache,id=pixelfed-composer-${PHP_VERSION}-${TARGETARCH},uid=${R
 
 # Copy all other files over
 COPY --chown=${RUNTIME_UID}:${RUNTIME_GID} src/ /var/www/
+
+#######################################################
+# Node: frontend stage selection
+#######################################################
+
+# When [BUILD_FRONTEND] is not 1 - the default, and what CI uses - there is
+# nothing for [frontend-build-1] to do, but it would still cost a [node:lts]
+# pull and a full copy of src/ on every build, only for [shared-runtime] to
+# copy /var/www/public straight back out again.
+#
+# Aliasing [frontend-build] on the value of [BUILD_FRONTEND] lets BuildKit
+# prune the node stage from the graph entirely, since [composer-and-src]
+# already carries an unmodified public/.
+#
+# ! NOTE: this has to come *after* [composer-and-src], as a Dockerfile stage
+# !       cannot reference a stage defined later in the file.
+FROM composer-and-src AS frontend-build-0
+
+FROM frontend-build-${BUILD_FRONTEND} AS frontend-build
 
 #######################################################
 # Runtime: base


### PR DESCRIPTION
Aggregating BuildKit stage timings **by name** across all 8 matrix jobs of run `31110402000` (step IDs collide between jobs, so per-ID reads are misleading):

| avg/job | stage |
|--:|---|
| **295s** | `linux/arm64 base 6/6` — `php.sh` (PECL/extension build) |
| **250s** | `linux/arm64 base 3/6` — `base.sh` (apt) |
| 43s | `linux/arm64 shared-runtime 3/8` |
| 38s | `linux/amd64 base 3/6` |
| 21s | `linux/amd64 base 6/6` |
| 15s | `linux/amd64 frontend-build 1/5` — pulling `node:lts` |

**arm64 under QEMU was 545s of the ~750s build — 73%** — for stages that take 59s natively on amd64. A 9× emulation penalty.

## Native arm64 runners

Each architecture now builds on a runner of that architecture, pushing untagged by digest, with a `merge` job assembling the manifest list. `ubuntu-24.04-arm` is free for public repos.

**Testing is now split from publishing.** The `test` job builds amd64 only, keeps it on the runner and runs goss + e2e against it — so test feedback no longer waits on the arm64 build or a registry round-trip.

Publishing is skipped entirely for Renovate PRs and fork PRs (nobody pulls those); human PRs still publish multi-arch so changes stay testable on arm64 hardware.

Job counts: **renovate PR 10** (was 10, but ~4 min instead of ~15), **human PR / main 34** (short and parallel).

## Build cache moved out of the image package

The cache now lives in `ghcr.io/jippi/docker-pixelfed-buildcache`, **not** in the image package. Reading a cache stored in the image package would be counted as pulls of the image, inflating the download numbers used to gauge real-world usage.

`docker-cleanup.yml` now reaps that package's orphans explicitly: the tags are a fixed set overwritten in place, but each rewrite orphans the manifest it replaced.

Moved off `actions/cache` because it's capped at 10 GB per repo — we were at **8.58 GB across 15 entries**, so entries were evicted before reuse and the newest buildx cache was **4 months old** (2026-03-25). Every build was falling back to it via `restore-keys`. Exported with `mode=max` now, so the expensive intermediate stages are cached rather than only final-image layers.

> [!IMPORTANT]
> One manual step after the first push: set the `docker-pixelfed-buildcache` package to **public**, otherwise fork PRs can't read it. They'd still build, just cold.

## `frontend-build` was dead weight

`BUILD_FRONTEND` defaults to `0` and nothing in CI sets it, so every build pulled `node:lts` and copied 72 MB of `src/` into it — only for `shared-runtime` to copy `/var/www/public` straight back out. Aliasing the stage on the arg value lets BuildKit prune it:

```dockerfile
FROM composer-and-src AS frontend-build-0
FROM frontend-build-${BUILD_FRONTEND} AS frontend-build
```

Verified with `buildx build --check`: `node:lts` is resolved only when `BUILD_FRONTEND=1`. `hadolint` clean at the project's `error` threshold.

## Fork PRs

Fork PRs were **already broken**: GitHub caps `GITHUB_TOKEN` to read-only for forks regardless of the requested `packages: write`, so `push: true` failed with a 403 before any test ran. They now build locally and test fine.

## Security notes

A registry cache is **not** scoped per branch the way `actions/cache` is — it's a mutable tag, so anything that can write it could inject layers into release images.

- `cache-to` is gated on `github.ref == 'refs/heads/main'`. PRs and `workflow_dispatch` on a side branch read the cache, never write it.
- Fork tokens are read-only anyway (defence in depth).
- `github.head_ref` is attacker-controlled but only used inside `startsWith()` in an `if:`/`env:` expression — never interpolated into a `run:`. Naming a branch `renovate/…` only *downgrades* to the no-publish path; the `head.repo.full_name` clause means a fork can never reach the publish path regardless of branch name.
- dottie installs from a pinned GitHub release over HTTPS instead of `deb [trusted=yes] https://pkg.jippi.dev/apt/`, which did no signature verification at all.

## Other

- Docs image build is cached (`type=gha`); it had no cache between runs at all.
- `docs.yml` only runs when something that ends up in the site changes; `workflow_dispatch` still runs it on demand.
- Concurrency groups on `docker-test.yml`, `docs.yml` and `lint.yml`. `docker-test` does not cancel in-progress runs on `main`, since those refresh the shared cache.

`actionlint` clean across all workflows.

## Deliberately not done

- **`.dockerignore`** — there is none, so the context ships this repo's `.git` plus a 72 MB `src/` with a 15 MB `.git`, and `COPY src/ /var/www/` copies `src/.git` into the image. Left alone per review feedback since the impact on pixelfed itself is unverified.
- **PR matrix reduction** — left at the full 8 entries.
- BuildKit `RUN --mount=type=cache` mounts (apt, pear) are still discarded between runs; `mode=max` layer caching should make this mostly moot, worth re-measuring before adding `buildkit-cache-dance`.
- `lint.yml`'s markdownlint globs `docs.io/**/*.md`, a directory that **does not exist** — that job currently lints nothing. Probably meant `docs/**/*.md`; fixing it may surface a backlog, so it's left for a separate PR.