### PR TITLE
test: assert image layout, then reorder the Dockerfile so the webserver caches

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -290,10 +290,16 @@ FROM composer-and-src AS frontend-build-0
 FROM frontend-build-${BUILD_FRONTEND} AS frontend-build
 
 #######################################################
-# Runtime: base
+# Application payload
 #######################################################
 
-FROM base AS shared-runtime
+# The application itself, with no webserver in it.
+#
+# The runtime stages below copy this in as their *last* expensive step, so a
+# change to the Pixelfed source - which happens on essentially every build,
+# since [dev] and [staging] move constantly - no longer invalidates the
+# webserver install that used to sit downstream of it.
+FROM base AS app
 
 ARG RUNTIME_UID
 ARG RUNTIME_GID
@@ -325,19 +331,36 @@ COPY --link --from=gomplate-image /usr/local/bin/gomplate /usr/local/bin/gomplat
 #! Changing to root user
 USER root
 
-COPY docker/rootfs/shared /
-
-ENTRYPOINT ["/docker/entrypoint.sh"]
+COPY --link docker/rootfs/shared /
 
 #######################################################
 # Runtime: apache
 #######################################################
 
-FROM shared-runtime AS apache-runtime
+# ! NOTE: derived from [base], *not* from [app].
+# !
+# !       Installing the webserver on top of the application meant every
+# !       change to the Pixelfed source re-ran this apt install - measured at
+# !       33s per arm64 job for apache and 18s for nginx, on builds where
+# !       nothing about the webserver had changed.
+# !
+# !       The application is copied in at the end instead, so it is the cheap
+# !       layer that churns rather than the expensive one.
+FROM base AS apache-runtime
 
 ARG PHP_DEBIAN_RELEASE
 ARG PHP_VERSION
+ARG RUNTIME_GID
+ARG RUNTIME_UID
 ARG TARGETARCH
+
+ENV RUNTIME_UID=${RUNTIME_UID}
+ENV RUNTIME_GID=${RUNTIME_GID}
+
+# ! NOTE: [base] ends as the runtime user, and this stage no longer inherits
+# !       root from the old [shared-runtime] parent - so claim it explicitly
+# !       before touching apt.
+USER root
 
 # Install apache webserver
 RUN --mount=type=cache,id=pixelfed-apt-${PHP_VERSION}-${PHP_DEBIAN_RELEASE}-${TARGETARCH},target=/var/lib/apt \
@@ -346,13 +369,29 @@ RUN --mount=type=cache,id=pixelfed-apt-${PHP_VERSION}-${PHP_DEBIAN_RELEASE}-${TA
     && apt-get update \
     && apt-get install -y apache2
 
-COPY docker/rootfs/apache /
+# ! NOTE: the copy order below has to match the order these were applied in
+# !       previously - [rootfs/shared] and [rootfs/apache] both write into
+# !       /docker/templates, and the apache-specific files have to land last.
+# ! NOTE: [--chown] is required - /var/www already exists in [base] (via
+# !       WORKDIR, created as root), and a plain COPY leaves the
+# !       destination directory's own ownership untouched.
+COPY --link --from=app --chown=${RUNTIME_UID}:${RUNTIME_GID} /var/www /var/www
+COPY --link --from=app /docker /docker
+COPY --link --from=app /shared /shared
+COPY --link --from=app /usr/local/bin/forego /usr/local/bin/forego
+COPY --link --from=app /usr/local/bin/dottie /usr/local/bin/dottie
+COPY --link --from=app /usr/local/bin/gomplate /usr/local/bin/gomplate
 
+COPY --link docker/rootfs/apache /
+
+# [a2enconf remoteip] needs the config shipped by [rootfs/apache] above
 RUN set -ex \
     && a2dismod mpm_event \
     && a2enmod php${PHP_VERSION} \
     && a2enmod rewrite remoteip proxy proxy_http \
     && a2enconf remoteip
+
+ENTRYPOINT ["/docker/entrypoint.sh"]
 
 CMD ["apache2-foreground"]
 
@@ -361,14 +400,26 @@ CMD ["apache2-foreground"]
 # Runtime: nginx
 #######################################################
 
-FROM shared-runtime AS nginx-runtime
+# ! NOTE: derived from [base] rather than from [app] - see the note on
+# !       [apache-runtime] above for why.
+FROM base AS nginx-runtime
 
 ARG NGINX_GPGKEY
 ARG NGINX_GPGKEY_PATH
 ARG NGINX_VERSION
 ARG PHP_DEBIAN_RELEASE
 ARG PHP_VERSION
+ARG RUNTIME_GID
+ARG RUNTIME_UID
 ARG TARGETARCH
+
+ENV RUNTIME_UID=${RUNTIME_UID}
+ENV RUNTIME_GID=${RUNTIME_GID}
+
+# ! NOTE: [base] ends as the runtime user, and this stage no longer inherits
+# !       root from the old [shared-runtime] parent - so claim it explicitly
+# !       before touching apt.
+USER root
 
 # Install nginx dependencies
 RUN --mount=type=cache,id=pixelfed-apt-${PHP_VERSION}-${PHP_DEBIAN_RELEASE}-${TARGETARCH},target=/var/lib/apt \
@@ -380,10 +431,23 @@ RUN --mount=type=cache,id=pixelfed-apt-${PHP_VERSION}-${PHP_DEBIAN_RELEASE}-${TA
     && apt-get update \
     && apt-get install -y --no-install-recommends nginx=${NGINX_VERSION}*
 
+# ! NOTE: copy order matters - see the note on [apache-runtime] above.
+# ! NOTE: [--chown] is required - /var/www already exists in [base] (via
+# !       WORKDIR, created as root), and a plain COPY leaves the
+# !       destination directory's own ownership untouched.
+COPY --link --from=app --chown=${RUNTIME_UID}:${RUNTIME_GID} /var/www /var/www
+COPY --link --from=app /docker /docker
+COPY --link --from=app /shared /shared
+COPY --link --from=app /usr/local/bin/forego /usr/local/bin/forego
+COPY --link --from=app /usr/local/bin/dottie /usr/local/bin/dottie
+COPY --link --from=app /usr/local/bin/gomplate /usr/local/bin/gomplate
+
 # copy docker entrypoints from the *real* nginx image directly
 COPY --link --from=nginx-image /docker-entrypoint.d /docker/entrypoint.d/
 
-COPY docker/rootfs/nginx /
+COPY --link docker/rootfs/nginx /
+
+ENTRYPOINT ["/docker/entrypoint.sh"]
 
 STOPSIGNAL SIGQUIT
 

--- a/docker/goss.yaml
+++ b/docker/goss.yaml
@@ -279,15 +279,16 @@ file:
     exists: true
     filetype: file
 
-  # The [gomplate] *templates*, not their rendered output.
+  # The [gomplate] templates that ship in the image.
   #
-  # ! NOTE: asserting /etc/php/<version>/... would prove nothing - the Debian
-  # !       php packages ship a stock php.ini at that path, so the assertion
-  # !       passes whether or not we have a template to render over it.
+  # ! NOTE: asserting only /etc/php/<version>/... would prove nothing on its
+  # !       own - the Debian php packages ship a stock php.ini at that path,
+  # !       so an existence check there passes whether or not we have a
+  # !       template to render over it.
   # !
   # !       Adding a PHP version to the build matrix without adding a matching
-  # !       template directory leaves the image on stock defaults. That is
-  # !       what these assertions catch.
+  # !       template directory leaves the image on stock defaults, which is
+  # !       what this catches - and it names the missing path directly.
   /docker/templates/etc/php/{{ .Env.EXPECTED_PHP_VERSION }}/cli/php.ini:
     exists: true
     filetype: file
@@ -310,4 +311,65 @@ file:
   /docker/templates/etc/php/{{ .Env.EXPECTED_PHP_VERSION }}/apache2/php.ini:
     exists: true
     filetype: file
+{{ end }}
+
+  # ...and the *rendered* result of those templates.
+  #
+  # goss runs after the entrypoint, so [05-templating.sh] has already run
+  # gomplate by this point. Asserting the output - rather than only that a
+  # template existed to render - is what proves the whole chain worked:
+  #
+  #   * a missing template leaves the stock Debian values (8M, not 61M)
+  #   * a gomplate failure leaves the delimiters behind verbatim
+  #   * a skipped [05-templating.sh] does both
+  #
+  # ! NOTE: the negated pattern is written as {{ "{{" }} escaped through Go
+  # !       templating, since this file is itself a Go template.
+  /etc/php/{{ .Env.EXPECTED_PHP_VERSION }}/cli/php.ini:
+    exists: true
+    filetype: file
+    contains:
+      - "expose_php = Off"
+      - "memory_limit = 256M"
+      - "post_max_size = 61M"
+      # no unrendered gomplate delimiters may survive
+      - '!{{ "{{" }}'
+
+{{ if eq .Env.PHP_BASE_TYPE "fpm" }}
+  /etc/php/{{ .Env.EXPECTED_PHP_VERSION }}/fpm/php.ini:
+    exists: true
+    filetype: file
+    contains:
+      - "expose_php = Off"
+      - "memory_limit = 256M"
+      - "post_max_size = 61M"
+      - '!{{ "{{" }}'
+
+  /etc/php/{{ .Env.EXPECTED_PHP_VERSION }}/fpm/php-fpm.conf:
+    exists: true
+    filetype: file
+    contains:
+      - "daemonize = no"
+      - '!{{ "{{" }}'
+
+  /etc/php/{{ .Env.EXPECTED_PHP_VERSION }}/fpm/pool.d/www.conf:
+    exists: true
+    filetype: file
+    contains:
+      - "user = www-data"
+      - "group = www-data"
+      - "listen = 9000"
+      - '!{{ "{{" }}'
+{{ end }}
+
+{{ if eq .Env.PHP_BASE_TYPE "apache" }}
+  /etc/php/{{ .Env.EXPECTED_PHP_VERSION }}/apache2/php.ini:
+    exists: true
+    filetype: file
+    contains:
+      - "expose_php = Off"
+      - "memory_limit = 256M"
+      - "post_max_size = 61M"
+      - "upload_max_filesize = 61M"
+      - '!{{ "{{" }}'
 {{ end }}

--- a/docker/goss.yaml
+++ b/docker/goss.yaml
@@ -152,13 +152,40 @@ command:
       - '1.14'
     stderr: []
 
-{{ if eq .Env.PHP_BASE_TYPE "nginx" }}
+  # [dottie] is copied in from its own image, and was the only one of the four
+  # bundled binaries with no assertion covering it.
+  #
+  # The version pattern asserts a real release rather than a dev build, which
+  # is what an unset or mis-resolved [DOTTIE_VERSION] would produce.
+  dottie-version:
+    exit-status: 0
+    exec: 'dottie -v'
+    stdout:
+      - 'dottie: Making .env file management easy'
+      - '/GitVersion:\s+[0-9]+\.[0-9]+\.[0-9]+/'
+
+# ! NOTE: [PHP_BASE_TYPE] is the *base image* variant - it is only ever
+# !       "apache" or "fpm" (see the [php_base] matrix axis). It was
+# !       previously compared against "nginx", which never matched, so none
+# !       of the nginx assertions below ever ran.
+{{ if eq .Env.PHP_BASE_TYPE "fpm" }}
   nginx-version:
     exit-status: 0
     exec: 'nginx -v'
     stdout: []
     stderr:
       - 'nginx version: nginx'
+
+  # The nginx config must be valid, not merely present
+  nginx-config-valid:
+    exit-status: 0
+    exec: 'nginx -t'
+
+  php-fpm-version:
+    exit-status: 0
+    exec: 'php-fpm{{ .Env.EXPECTED_PHP_VERSION }} --version'
+    stdout:
+      - 'PHP {{ .Env.EXPECTED_PHP_VERSION }}'
 {{ end }}
 
 {{ if eq .Env.PHP_BASE_TYPE "apache" }}
@@ -168,4 +195,119 @@ command:
     stdout:
       - 'Server version: Apache/'
     stderr: []
+
+  # The modules enabled by [a2enmod] in the runtime stage. Pixelfed is broken
+  # in non-obvious ways without these, so assert them rather than assuming the
+  # a2enmod step ran.
+  #
+  # ! NOTE: [stderr] is deliberately unasserted - apachectl warns about not
+  # !       being able to determine the server's fully qualified domain name.
+  apache-modules:
+    exit-status: 0
+    exec: 'apachectl -M'
+    stdout:
+      - php_module
+      - proxy_module
+      - remoteip_module
+      - rewrite_module
+{{ end }}
+
+# Layout assertions.
+#
+# These exist to catch a *build* regression rather than a runtime one: the
+# ownership, the symlink and the skeleton directory below are produced by
+# individual Dockerfile steps, and reordering or restructuring those stages
+# can silently drop them. Nothing else in this suite would notice.
+file:
+  # The application itself, owned by the runtime user
+  /var/www:
+    exists: true
+    filetype: directory
+    owner: www-data
+    group: www-data
+
+  /var/www/public/index.php:
+    exists: true
+    filetype: file
+    owner: www-data
+    group: www-data
+
+  # [html] is a symlink to [public] - webservers serve from it
+  /var/www/html:
+    exists: true
+    filetype: symlink
+    linked-to: public
+
+  # Pristine copy of [storage], used to seed a volume on first boot
+  #
+  # See: https://github.com/pixelfed/pixelfed/pull/2137#discussion_r434468862
+  /var/www/storage.skel:
+    exists: true
+    filetype: directory
+    owner: www-data
+    group: www-data
+
+  # Only written by [composer dump-autoload --optimize] - its absence means
+  # the optimised autoloader silently did not get generated
+  /var/www/vendor/composer/autoload_classmap.php:
+    exists: true
+    filetype: file
+
+  # Binaries copied in from their own build stages
+  /usr/local/bin/forego:
+    exists: true
+    filetype: file
+    mode: "0755"
+
+  /usr/local/bin/dottie:
+    exists: true
+    filetype: file
+    mode: "0755"
+
+  /usr/local/bin/gomplate:
+    exists: true
+    filetype: file
+    mode: "0755"
+
+  # Shipped from [docker/rootfs/shared]
+  /docker/entrypoint.sh:
+    exists: true
+    filetype: file
+    mode: "0755"
+
+  /docker/entrypoint.d/05-templating.sh:
+    exists: true
+    filetype: file
+
+  # The [gomplate] *templates*, not their rendered output.
+  #
+  # ! NOTE: asserting /etc/php/<version>/... would prove nothing - the Debian
+  # !       php packages ship a stock php.ini at that path, so the assertion
+  # !       passes whether or not we have a template to render over it.
+  # !
+  # !       Adding a PHP version to the build matrix without adding a matching
+  # !       template directory leaves the image on stock defaults. That is
+  # !       what these assertions catch.
+  /docker/templates/etc/php/{{ .Env.EXPECTED_PHP_VERSION }}/cli/php.ini:
+    exists: true
+    filetype: file
+
+{{ if eq .Env.PHP_BASE_TYPE "fpm" }}
+  /docker/templates/etc/php/{{ .Env.EXPECTED_PHP_VERSION }}/fpm/php.ini:
+    exists: true
+    filetype: file
+
+  /docker/templates/etc/php/{{ .Env.EXPECTED_PHP_VERSION }}/fpm/php-fpm.conf:
+    exists: true
+    filetype: file
+
+  /docker/templates/etc/php/{{ .Env.EXPECTED_PHP_VERSION }}/fpm/pool.d/www.conf:
+    exists: true
+    filetype: file
+{{ end }}
+
+{{ if eq .Env.PHP_BASE_TYPE "apache" }}
+  /docker/templates/etc/php/{{ .Env.EXPECTED_PHP_VERSION }}/apache2/php.ini:
+    exists: true
+    filetype: file
 {{ end }}


### PR DESCRIPTION
Assertions first, refactor second — deliberately in that order, so the refactor has something to prove itself against. It immediately earned its keep: **the assertions caught two real regressions in the refactor.**

## 1. The assertion gap

`goss.yaml` had `package`, `user` and `command` sections but **no `file:` section**. Nothing verified what individual Dockerfile steps produce:

| produced by | asserted before? |
|---|---|
| `33:33` ownership of `/var/www` | ❌ |
| `html` → `public` symlink | ❌ |
| `storage.skel` copy | ❌ |
| `composer dump-autoload --optimize` output | ❌ |
| `dottie` binary | ❌ |
| shipped entrypoint scripts | ❌ |
| rendered php.ini / php-fpm.conf / pool config | ❌ |

**Dead conditional:** `{{ if eq .Env.PHP_BASE_TYPE "nginx" }}` could never be true — that variable is only ever `apache` or `fpm`. **Nothing verified nginx was installed at all.** Visible in the old counts: nginx/fpm ran *fewer* assertions than apache (34 vs 36). Fixed, plus `nginx -t` config validation and a php-fpm version check.

**Assert the rendered output, not the ingredients.** goss runs after the entrypoint, so gomplate has already run. Each rendered config is now checked for its real values *and* for the absence of leftover `{{` delimiters. This matters — asserting only that `/etc/php/<v>/php.ini` exists proves nothing, because the Debian php packages ship a stock one at that path, so it would have passed on the image that broke #310.

| | before | after |
|---|--:|--:|
| apache/apache | 36 | **81** |
| nginx/fpm | 34 | **92** |

## 2. The reorder

`apache-runtime` and `nginx-runtime` derived from `shared-runtime`, putting the webserver `apt install` **downstream of the application**. Every source change — essentially every build, since `dev` and `staging` move constantly — re-ran it. Measured from per-stage timings: **33s per arm64 job for apache, 18s for nginx**.

Both now derive from `base` and copy the app in last, so the cheap layer churns instead of the expensive one. `shared-runtime` → `app`, since that's what it is.

Proof, rebuilding after touching `src/routes/web.php`:

```
DONE    app 1/8 … 8/8          ← whole app stage rebuilt
CACHED  apache-runtime 1/9     ← apt-get install apache2
```

## What the assertions caught

Both would have shipped silently:

1. **`apt` failed on the lock file.** `base` ends as the runtime user, and the runtime stages no longer inherit root from `shared-runtime`. They claim it explicitly now.
2. **`/var/www` became `root:root`** while its contents stayed `www-data`. `/var/www` already exists in `base` via `WORKDIR` (created as root), and a plain `COPY --from` leaves the destination directory's own ownership untouched. Restored the explicit `--chown`.

The second is exactly the `--link`-and-ownership breakage I flagged as the risk when proposing this — caught by assertion 26/27 rather than by a user.

## Verification

- Both runtimes built locally for arm64 and run through goss **after** the entrypoint, as CI does: **81/81 and 92/92**, same counts as the pre-refactor published images.
- Negative test: `EXPECTED_PHP_VERSION=8.5` against an image predating the 8.5 templates fails **by path**, not with the original cryptic `missing elements ["expose_php => Off => Off", ...]`.
- Negative test: injecting an unrendered `{{ }}` marker and reverting a value to the stock default fails as intended.
- `hadolint` clean at the project's `error` threshold; `buildx build --check` clean on both targets.