### PR TITLE
fix: point markdownlint at a directory that exists

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,4 +52,13 @@ jobs:
         uses: DavidAnson/markdownlint-cli2-action@v22
         with:
           config: .markdownlint.yml
-          globs: "docs.io/**/*.md"
+          # ! NOTE: this used to point at [docs.io/**/*.md] - a directory that
+          # !       does not exist in this repository - so the job matched no
+          # !       files and passed without linting anything.
+          # !
+          # !       [settings.md] is generated from [.env.docker] by dottie and
+          # !       is gitignored, so it is absent here but present in the docs
+          # !       workflow. Excluding it keeps local runs consistent with CI.
+          globs: |
+            docs/**/*.md
+            !docs/customize/settings.md


### PR DESCRIPTION
The `markdownlint` job has been passing without linting anything.

```yaml
globs: "docs.io/**/*.md"    # no such directory in this repo
```

Zero files matched, so the job reported success. Found while auditing the workflows in #346.

## The fix

```yaml
globs: |
  docs/**/*.md
  !docs/customize/settings.md
```

**No backlog behind it** — all 12 tracked files under `docs/` pass as-is:

```
Linting: 12 files
Summary: 0 issues in 0 files
```

## Why `settings.md` is excluded

It's generated from `.env.docker` by `dottie template` and is **gitignored**, so:

- In the **lint** workflow's checkout it doesn't exist — the exclusion is a no-op there.
- **Locally**, once you've run the docs workflow, it does exist and carries **151 violations** (149 × `MD012/no-multiple-blanks`, 2 × `MD034/no-bare-urls`) — all artifacts of `docs-customization/template/dot-env.template.tmpl`, not hand-written prose.

Excluding it explicitly keeps a local run consistent with CI rather than failing only on developer machines.

## Scope

Deliberately limited to `docs/`, matching the original intent. Linting every tracked `*.md` would additionally cover `.github/ISSUE_TEMPLATE/*.md`, which currently has 4 violations — worth a separate decision, not a drive-by.